### PR TITLE
Kernel network stack bypass

### DIFF
--- a/drivers/staging/Kconfig
+++ b/drivers/staging/Kconfig
@@ -64,4 +64,6 @@ source "drivers/staging/fieldbus/Kconfig"
 
 source "drivers/staging/vme_user/Kconfig"
 
+source "drivers/staging/remote_numa/Kconfig"
+
 endif # STAGING

--- a/drivers/staging/Makefile
+++ b/drivers/staging/Makefile
@@ -21,3 +21,4 @@ obj-$(CONFIG_GREYBUS)		+= greybus/
 obj-$(CONFIG_BCM2835_VCHIQ)	+= vc04_services/
 obj-$(CONFIG_XIL_AXIS_FIFO)	+= axis-fifo/
 obj-$(CONFIG_FIELDBUS_DEV)     += fieldbus/
+obj-$(CONFIG_REMOTE_NUMA)      += remote_numa/

--- a/drivers/staging/remote_numa/Kconfig
+++ b/drivers/staging/remote_numa/Kconfig
@@ -1,0 +1,1 @@
+source "drivers/staging/remote_numa/ping_tests/Kconfig"

--- a/drivers/staging/remote_numa/Makefile
+++ b/drivers/staging/remote_numa/Makefile
@@ -1,0 +1,1 @@
+obj-$(CONFIG_REMOTE_NUMA)      = ping_tests/

--- a/drivers/staging/remote_numa/ping_tests/Kconfig
+++ b/drivers/staging/remote_numa/ping_tests/Kconfig
@@ -1,0 +1,5 @@
+config REMOTE_NUMA
+    tristate "My Test Modules for remote numa"
+    default m
+    help
+        Experimental remote NUMA memory/test modules.

--- a/drivers/staging/remote_numa/ping_tests/Makefile
+++ b/drivers/staging/remote_numa/ping_tests/Makefile
@@ -1,0 +1,1 @@
+obj-$(CONFIG_REMOTE_NUMA) += kernel_custom.o kernel_custom_client.o pointer_print.o server_handler.o client_handler.o

--- a/drivers/staging/remote_numa/ping_tests/client_handler.c
+++ b/drivers/staging/remote_numa/ping_tests/client_handler.c
@@ -1,0 +1,121 @@
+// kernel_custom_client.c
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/netdevice.h>
+#include <linux/etherdevice.h>
+#include <linux/skbuff.h>
+#include <linux/kthread.h>
+#include <linux/delay.h>
+#include <linux/ktime.h>
+
+#define MY_ETHERTYPE 0x88b5
+#define DST_MAC "\x52\x54\x00\x00\x00\x01"	// Server MAC
+#define SRC_MAC "\x52\x54\x00\x00\x00\x02"	// Client MAC
+#define IFACE   "eth0"
+
+static struct task_struct *ping_thread;
+static struct net_device *dev;
+static u64 last_tx_time;
+static int waiting_reply;
+static u64 rtt_ns;
+
+static int
+client_handler(struct sk_buff *skb, struct net_device *dev,
+	       struct packet_type *pt, struct net_device *orig_dev)
+{
+	struct ethhdr *eth = eth_hdr(skb);
+	if (memcmp(eth->h_source, DST_MAC, ETH_ALEN) == 0 &&
+	    memcmp(eth->h_dest, SRC_MAC, ETH_ALEN) == 0 &&
+	    skb->protocol == htons(MY_ETHERTYPE) && waiting_reply) {
+		rtt_ns = ktime_get_ns() - last_tx_time;
+		waiting_reply = 0;
+		printk(KERN_INFO
+		       "custom client: reply received, rtt = %llu ns (%llu us)\n",
+		       rtt_ns, rtt_ns / 1000);
+	}
+	kfree_skb(skb);
+	return NET_RX_SUCCESS;
+}
+
+static struct packet_type my_ptype __read_mostly = {
+	.type = cpu_to_be16(MY_ETHERTYPE),
+	.func = client_handler,
+};
+
+static int
+ping_loop(void *data)
+{
+	struct sk_buff *skb;
+	struct ethhdr *eth;
+	int len = 60;		// Minimum Ethernet
+	int i;
+
+	allow_signal(SIGKILL);
+
+	while (!kthread_should_stop()) {
+		skb = alloc_skb(len + NET_IP_ALIGN, GFP_KERNEL);
+		if (!skb)
+			break;
+		skb_reserve(skb, NET_IP_ALIGN);
+
+		eth = (struct ethhdr *)skb_put(skb, sizeof(struct ethhdr));
+		ether_addr_copy(eth->h_dest, DST_MAC);
+		ether_addr_copy(eth->h_source, SRC_MAC);
+		eth->h_proto = htons(MY_ETHERTYPE);
+
+		memset(skb_put(skb, len - sizeof(struct ethhdr)), 0,
+		       len - sizeof(struct ethhdr));
+
+		skb->dev = dev;
+		skb->protocol = htons(MY_ETHERTYPE);
+
+		last_tx_time = ktime_get_ns();
+		waiting_reply = 1;
+		dev_queue_xmit(skb);
+
+		// Wait up to 1 second for reply
+		for (i = 0; i < 100; ++i) {
+			if (!waiting_reply)
+				break;
+			msleep(10);
+		}
+		if (waiting_reply) {
+			printk(KERN_INFO
+			       "custom client: timeout waiting for reply\n");
+			waiting_reply = 0;
+		}
+		ssleep(1);	// send next ping every 1s
+	}
+	return 0;
+}
+
+static int __init
+ping_init(void)
+{
+	dev = dev_get_by_name(&init_net, IFACE);
+	if (!dev)
+		return -ENODEV;
+	dev_add_pack(&my_ptype);
+	ping_thread = kthread_run(ping_loop, NULL, "custom_ping_thread");
+	printk(KERN_INFO "custom client: started\n");
+	return 0;
+}
+
+static void __exit
+ping_exit(void)
+{
+	if (ping_thread)
+		kthread_stop(ping_thread);
+	if (dev)
+		dev_put(dev);
+	dev_remove_pack(&my_ptype);
+	printk(KERN_INFO "custom client: stopped\n");
+}
+
+module_init(ping_init);
+module_exit(ping_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("You");
+MODULE_DESCRIPTION("Custom Ethertype client with RTT timing");

--- a/drivers/staging/remote_numa/ping_tests/kernel_custom.c
+++ b/drivers/staging/remote_numa/ping_tests/kernel_custom.c
@@ -1,0 +1,84 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/skbuff.h>
+#include <linux/etherdevice.h>
+#include <linux/netdevice.h>
+#include <linux/net_custom_hook.h>
+
+#define MY_PROTO htons(0x88B5)
+
+#define ETH_MIN_FRAME 60
+
+#define ETH_MIN_FRAME 60
+
+static custom_net_hook_ret_t
+my_custom_handler(struct sk_buff *skb)
+{
+	struct ethhdr *eth = eth_hdr(skb);
+	struct net_device *dev = skb->dev;
+	int pay_len = skb->len - sizeof(struct ethhdr);
+	int tx_len = sizeof(struct ethhdr) + (pay_len > 0 ? pay_len : 0);
+	int pad_len = (tx_len < ETH_MIN_FRAME) ? (ETH_MIN_FRAME - tx_len) : 0;
+	struct sk_buff *txskb;
+	struct ethhdr *eth_tx;
+	u8 orig_src[ETH_ALEN];
+
+	if (skb->protocol != htons(0x88b5))
+		return custom_net_hook_not_consumed;
+	if (skb->len < sizeof(struct ethhdr))
+		goto err;
+
+	ether_addr_copy(orig_src, eth->h_source);
+
+	txskb = alloc_skb(ETH_MIN_FRAME + NET_IP_ALIGN, GFP_ATOMIC);
+	if (!txskb) {
+		goto err;
+	}
+	skb_reserve(txskb, NET_IP_ALIGN);
+
+	// Ethernet header first
+	eth_tx = (struct ethhdr *)skb_put(txskb, sizeof(struct ethhdr));
+	ether_addr_copy(eth_tx->h_dest, orig_src);
+	ether_addr_copy(eth_tx->h_source, dev->dev_addr);
+	eth_tx->h_proto = htons(0x88b5);
+
+	// Copy payload
+	if (pay_len > 0)
+		skb_put_data(txskb, skb->data + sizeof(struct ethhdr), pay_len);
+
+	// Pad to minimum length
+	if (pad_len > 0)
+		memset(skb_put(txskb, pad_len), 0, pad_len);
+
+	txskb->dev = dev;
+	txskb->protocol = htons(0x88b5);
+	txskb->pkt_type = PACKET_OUTGOING;
+	skb_reset_network_header(txskb);
+
+	if (0 == dev_queue_xmit(txskb))
+		return custom_net_hook_consumed;
+
+err:
+	kfree_skb(skb);
+	return custom_net_hook_consumed_with_error;
+}
+
+static int __init
+custom_eth_init(void)
+{
+	printk(KERN_INFO "Registering custom low-latency ethertype handler\n");
+	custom_net_hook = my_custom_handler;
+	return 0;
+}
+
+static void __exit
+custom_eth_exit(void)
+{
+	custom_net_hook = NULL;
+	printk(KERN_INFO "Unregistered custom handler\n");
+}
+
+module_init(custom_eth_init);
+module_exit(custom_eth_exit);
+MODULE_LICENSE("GPL");

--- a/drivers/staging/remote_numa/ping_tests/kernel_custom_client.c
+++ b/drivers/staging/remote_numa/ping_tests/kernel_custom_client.c
@@ -1,0 +1,151 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/netdevice.h>
+#include <linux/etherdevice.h>
+#include <linux/skbuff.h>
+#include <linux/kthread.h>
+#include <linux/delay.h>
+#include <linux/timekeeping.h>
+#include <linux/if_ether.h>
+#include <linux/string.h>
+#include <linux/net_custom_hook.h>	// your patch's header!
+
+#define ETH_P_CUSTOM 0x88B5
+#define PAYLOAD "KERNELPING"
+#define INTERVAL_MS 500
+
+static char ifname[] = "eth0";
+module_param_string(ifname, ifname, sizeof(ifname), 0444);
+
+static u8 server_mac[ETH_ALEN] = { 0x52, 0x54, 0x00, 0x00, 0x00, 0x01 };
+static u8 client_mac[ETH_ALEN] = { 0x52, 0x54, 0x00, 0x00, 0x00, 0x02 };
+
+static struct net_device *dev;
+static struct task_struct *kthread;
+static int seq = 0;
+static ktime_t last_send_time;
+static bool handler_registered = false;
+
+static custom_net_hook_ret_t
+my_custom_handler(struct sk_buff *skb)
+{
+	struct ethhdr *eth;
+
+	if (skb->protocol != htons(ETH_P_CUSTOM)) {
+		return custom_net_hook_not_consumed;	// Not our proto
+	}
+
+	eth = eth_hdr(skb);
+	// Is this an echo from the server?
+	if (ether_addr_equal(eth->h_dest, client_mac) &&
+	    ether_addr_equal(eth->h_source, server_mac) &&
+	    skb->len >= sizeof(struct ethhdr) + sizeof(PAYLOAD)) {
+
+		ktime_t now = ktime_get();
+		u64 rtt_us = ktime_to_ns(ktime_sub(now, last_send_time)) / 1000;
+		printk(KERN_INFO
+		       "raw_eth_client: got echo reply! RTT: %llu us (seq %d)\n",
+		       rtt_us, seq);
+		kfree_skb(skb);
+		return custom_net_hook_consumed;	// handled
+	} else {
+		printk(KERN_INFO "NOT A REPLY!");
+	}
+
+	printk(KERN_INFO "Error. Dropping frame.");
+	kfree_skb(skb);
+	return custom_net_hook_consumed_with_error;
+}
+
+static int
+client_thread(void *data)
+{
+	while (!kthread_should_stop()) {
+		struct sk_buff *skb;
+		struct ethhdr *eth;
+		size_t pkt_size = sizeof(struct ethhdr) + sizeof(PAYLOAD);
+		int err;
+
+		skb = alloc_skb(pkt_size + NET_IP_ALIGN, GFP_KERNEL);
+		if (!skb) {
+			msleep(INTERVAL_MS);
+			continue;
+		}
+
+		skb_reserve(skb, NET_IP_ALIGN);
+		skb_reset_network_header(skb);
+
+		eth = (struct ethhdr *)skb_put(skb, sizeof(struct ethhdr));
+		ether_addr_copy(eth->h_dest, server_mac);
+		ether_addr_copy(eth->h_source, client_mac);
+		eth->h_proto = htons(ETH_P_CUSTOM);
+
+		memcpy(skb_put(skb, sizeof(PAYLOAD)), PAYLOAD, sizeof(PAYLOAD));
+
+		skb->dev = dev;
+		skb->protocol = eth->h_proto;
+		skb->priority = 0;
+
+		last_send_time = ktime_get();
+		++seq;
+
+		err = dev_queue_xmit(skb);
+		if (err)
+			printk(KERN_ERR
+			       "raw_eth_client: dev_queue_xmit failed: %d\n",
+			       err);
+
+		msleep(INTERVAL_MS);
+	}
+	return 0;
+}
+
+static int __init
+raw_eth_client_init(void)
+{
+	dev = dev_get_by_name(&init_net, ifname);
+	if (!dev) {
+		printk(KERN_ERR "raw_eth_client: cannot find interface %s\n",
+		       ifname);
+		return -ENODEV;
+	}
+
+	// Register handler
+	if (custom_net_hook)
+		printk(KERN_WARNING
+		       "raw_eth_client: handler already registered!\n");
+	custom_net_hook = my_custom_handler;
+	handler_registered = true;
+
+	kthread = kthread_run(client_thread, NULL, "raw_eth_client");
+	if (IS_ERR(kthread)) {
+		printk(KERN_ERR "raw_eth_client: kthread_run failed\n");
+		custom_net_hook = NULL;
+		handler_registered = false;
+		dev_put(dev);
+		return PTR_ERR(kthread);
+	}
+
+	printk(KERN_INFO "raw_eth_client: loaded, pinging %pM from %pM on %s\n",
+	       server_mac, client_mac, ifname);
+	return 0;
+}
+
+static void __exit
+raw_eth_client_exit(void)
+{
+	if (kthread)
+		kthread_stop(kthread);
+	if (handler_registered)
+		custom_net_hook = NULL;
+	if (dev)
+		dev_put(dev);
+	printk(KERN_INFO "raw_eth_client: unloaded\n");
+}
+
+module_init(raw_eth_client_init);
+module_exit(raw_eth_client_exit);
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("You");
+MODULE_DESCRIPTION("Raw Ethernet kernel ping client (for early RX hook)");

--- a/drivers/staging/remote_numa/ping_tests/pointer_print.c
+++ b/drivers/staging/remote_numa/ping_tests/pointer_print.c
@@ -1,0 +1,21 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+#include <linux/net_custom_hook.h>
+
+static int __init
+show_hook_init(void)
+{
+	printk(KERN_INFO "custom_net_hook pointer: %px\n", custom_net_hook);
+	return -EIO;		// fail so it auto-unloads (or return 0 to keep loaded)
+}
+
+static void __exit
+show_hook_exit(void)
+{
+}
+
+module_init(show_hook_init);
+module_exit(show_hook_exit);
+MODULE_LICENSE("GPL");

--- a/drivers/staging/remote_numa/ping_tests/server_handler.c
+++ b/drivers/staging/remote_numa/ping_tests/server_handler.c
@@ -1,0 +1,88 @@
+// kernel_custom_server.c
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/netdevice.h>
+#include <linux/etherdevice.h>
+#include <linux/skbuff.h>
+
+#define MY_ETHERTYPE 0x88b5
+
+static int
+my_proto_handler(struct sk_buff *skb, struct net_device *dev,
+		 struct packet_type *pt, struct net_device *orig_dev)
+{
+	struct ethhdr *rx_eth = eth_hdr(skb);
+	struct sk_buff *txskb;
+	struct ethhdr *tx_eth;
+	int payload_len = skb->len - sizeof(struct ethhdr);
+	int min_payload = 46;
+	int total_len =
+	    sizeof(struct ethhdr) + max_t(int, payload_len, min_payload);
+
+	// Sanity check incoming frame
+	if (skb->len < sizeof(struct ethhdr))
+		goto drop;
+
+	// Allocate new skb for reply
+	txskb = alloc_skb(total_len + NET_IP_ALIGN, GFP_ATOMIC);
+	if (!txskb)
+		goto drop;
+	skb_reserve(txskb, NET_IP_ALIGN);
+
+	// Set Ethernet header
+	tx_eth = (struct ethhdr *)skb_put(txskb, sizeof(struct ethhdr));
+	ether_addr_copy(tx_eth->h_dest, rx_eth->h_source);	// Reply to sender
+	ether_addr_copy(tx_eth->h_source, dev->dev_addr);	// From us
+	tx_eth->h_proto = htons(MY_ETHERTYPE);
+
+	// Copy payload (if present)
+	if (payload_len > 0)
+		skb_put_data(txskb, skb->data + sizeof(struct ethhdr),
+			     payload_len);
+
+	// Pad as necessary
+	if (payload_len < min_payload)
+		memset(skb_put(txskb, min_payload - payload_len), 0,
+		       min_payload - payload_len);
+
+	txskb->dev = dev;
+	txskb->protocol = htons(MY_ETHERTYPE);
+
+	// Required for most devices:
+	skb_reset_mac_header(txskb);
+	skb->dev = dev;
+
+	dev_queue_xmit(txskb);
+
+      drop:
+	kfree_skb(skb);
+	return NET_RX_SUCCESS;
+}
+
+static struct packet_type my_ptype __read_mostly = {
+	.type = cpu_to_be16(MY_ETHERTYPE),
+	.func = my_proto_handler,
+};
+
+static int __init
+my_proto_init(void)
+{
+	dev_add_pack(&my_ptype);
+	printk(KERN_INFO "custom server: registered protocol handler\n");
+	return 0;
+}
+
+static void __exit
+my_proto_exit(void)
+{
+	dev_remove_pack(&my_ptype);
+	printk(KERN_INFO "custom server: unregistered protocol handler\n");
+}
+
+module_init(my_proto_init);
+module_exit(my_proto_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("You");
+MODULE_DESCRIPTION("Custom Ethertype server (echo)");

--- a/include/linux/net_custom_hook.h
+++ b/include/linux/net_custom_hook.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * custom_net_hook.h - Hook for low-latency network frame rx.
+ *
+ * Copyright (C) 2024 Trevor Kemp
+ */
+
+
+#ifndef _CUSTOM_NET_HOOK_H
+#define _CUSTOM_NET_HOOK_H
+#include <linux/skbuff.h>
+
+typedef enum custom_net_hook_ret
+{
+	custom_net_hook_consumed = 0,
+	custom_net_hook_consumed_with_error,
+	custom_net_hook_not_consumed,
+} custom_net_hook_ret_t;
+
+typedef custom_net_hook_ret_t (*custom_net_hook_fn_t)(struct sk_buff *skb);
+
+/*
+ * Called inside napi_gro_receive() to give us a low-latency path to
+ * exmaine and act on network frames. By doing this here, we get the
+ * lowest-latency path possible without having to modify netdev drivers.
+ */
+extern volatile custom_net_hook_fn_t custom_net_hook;
+
+#endif

--- a/net/core/Makefile
+++ b/net/core/Makefile
@@ -7,6 +7,8 @@ obj-y := sock.o request_sock.o skbuff.o datagram.o stream.o scm.o \
 	 gen_stats.o gen_estimator.o net_namespace.o secure_seq.o \
 	 flow_dissector.o
 
+obj-y += custom_net_hook.o
+
 obj-$(CONFIG_SYSCTL) += sysctl_net_core.o
 
 obj-y		     += dev.o dev_addr_lists.o dst.o netevent.o \
@@ -14,6 +16,7 @@ obj-y		     += dev.o dev_addr_lists.o dst.o netevent.o \
 			sock_diag.o dev_ioctl.o tso.o sock_reuseport.o \
 			fib_notifier.o xdp.o flow_offload.o gro.o \
 			netdev-genl.o netdev-genl-gen.o gso.o
+obj-y += custom_net_hook.o
 
 obj-$(CONFIG_NETDEV_ADDR_LIST_TEST) += dev_addr_lists_test.o
 

--- a/net/core/custom_net_hook.c
+++ b/net/core/custom_net_hook.c
@@ -1,0 +1,9 @@
+/* net/core/custom_net_hook.c */
+#include <linux/module.h>
+#include <linux/skbuff.h>
+#include <linux/export.h>
+#include <linux/net_custom_hook.h>
+
+volatile custom_net_hook_fn_t custom_net_hook = NULL;
+EXPORT_SYMBOL(custom_net_hook);
+

--- a/net/core/gro.c
+++ b/net/core/gro.c
@@ -5,6 +5,8 @@
 #include <trace/events/net.h>
 #include <linux/skbuff_ref.h>
 
+#include <linux/net_custom_hook.h>
+
 #define MAX_GRO_SKBS 8
 
 static DEFINE_SPINLOCK(offload_lock);
@@ -622,17 +624,25 @@ static gro_result_t napi_skb_finish(struct napi_struct *napi,
 
 gro_result_t napi_gro_receive(struct napi_struct *napi, struct sk_buff *skb)
 {
-	gro_result_t ret;
+        gro_result_t ret;
 
-	skb_mark_napi_id(skb, napi);
-	trace_napi_gro_receive_entry(skb);
+        // ---- CUSTOM HOOK: Early exit if handled ----
+        if (custom_net_hook && (custom_net_hook(skb) !=
+	    custom_net_hook_not_consumed)) {
+                // Packet consumed, don't process further
+                return 0;
+        }
+        // --------------------------------------------
 
-	skb_gro_reset_offset(skb, 0);
+        skb_mark_napi_id(skb, napi);
+        trace_napi_gro_receive_entry(skb);
 
-	ret = napi_skb_finish(napi, skb, dev_gro_receive(napi, skb));
-	trace_napi_gro_receive_exit(ret);
+        skb_gro_reset_offset(skb, 0);
 
-	return ret;
+        ret = napi_skb_finish(napi, skb, dev_gro_receive(napi, skb));
+        trace_napi_gro_receive_exit(ret);
+
+        return ret;
 }
 EXPORT_SYMBOL(napi_gro_receive);
 


### PR DESCRIPTION
Tested on June 15. There were 2 kernel modules, one for each of 2 hosts, and it showed a massive improvement in RTT between two QEMU instances connected on the same host through tap interfaces over a bridge. Userspace ping was ~3ms. Kernelspace raw frame "ping" was 800us.

Additional experiments performed with kernel modules registering a handler for the custom protocol. This removes the need for kernel patching, but adds about 30us in this setup. So we use the simple kernel patch.