### PR TITLE
use worker threads, not direct IRQ context.

### DIFF
--- a/drivers/staging/remote_numa/Makefile
+++ b/drivers/staging/remote_numa/Makefile
@@ -3,6 +3,6 @@ obj-$(CONFIG_REMOTE_NUMA)      += ping_tests/
 obj-$(CONFIG_REMOTE_NUMA) += main_node_module.o
 obj-$(CONFIG_REMOTE_NUMA) += donor_node_module.o
 
-main_node_module-objs := main_node.o eth_transport.o transport.o
-donor_node_module-objs := donor_node.o eth_transport.o transport.o
+main_node_module-objs := main_node.o eth_transport.o transport.o memory.o worker_pool.o
+donor_node_module-objs := donor_node.o eth_transport.o transport.o memory.o worker_pool.o
 

--- a/drivers/staging/remote_numa/donor_node.c
+++ b/drivers/staging/remote_numa/donor_node.c
@@ -5,10 +5,12 @@
  * Copyright (C) 2025 Trevor Kemp
  */
 
+#include <linux/compiler.h>
 #include <linux/delay.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/kthread.h>
+#include <linux/llist.h>
 #include <linux/net_custom_hook.h>
 #include <linux/module.h>
 #include <linux/random.h>
@@ -16,39 +18,24 @@
 
 #include "eth_transport.h"
 #include "protocol.h"
+#include "worker_pool.h"
 
 #define ADVERT_MIN_SLEEP_MS 3000
 #define ADVERT_RANDOM_SLEEP_MS_MAX 500
+#define WORKER_POOL_SIZE 4
+
+#define PG_SZ 4096
+#define NUM_PGS 128000
 
 static struct task_struct *kthread = NULL;
-remote_numa_donor_trprt_if_t *ctx = NULL;
+static remote_numa_donor_trprt_if_t *ctx = NULL;
+static remote_numa_mem_mgr_t *mem;
 
-static custom_net_hook_ret_t
-donor_skb_handler(struct sk_buff *skb)
+static remote_numa_receive_ret_t rx_wrapper(void *frame)
 {
-	/*
- 	 * TODO we should really be doing any work on a worker thread
- 	 * and not in the unterrupt context.
- 	 */  
-	if (skb->protocol != REMOTE_NUMA_ETHERTYPE)
-		return custom_net_hook_not_consumed;
-
-	u8 *payload;
-	if (skb_mac_header_was_set(skb))
-		payload = skb_mac_header(skb) + ETH_HLEN;
-	else
-		payload = skb->data + ETH_HLEN;
-	
-	remote_numa_receive_ret_t tmp_ret = remote_numa_donor_rx(ctx, payload);
-	kfree_skb(skb);
-
-	if (tmp_ret)
-	{
-		return custom_net_hook_consumed_with_error;
-	}
-
-	return custom_net_hook_consumed;
-
+	void *payload = NULL;
+	ctx->prepare_rx_buff(frame, &payload);
+	return remote_numa_donor_rx(ctx, frame, payload);
 }
 
 static int
@@ -67,19 +54,26 @@ advert_thread(void *data)
 static int __init
 remote_numa_donor_node_init(void)
 {
-	ctx = remote_numa_eth_donor_init(donor_skb_handler);
+	mem = remote_numa_create_mem_mgr(PG_SZ * NUM_PGS);
+	if (!mem)
+		return -ENOMEM;
+	remote_numa_worker_pool_init(rx_wrapper, WORKER_POOL_SIZE);
+
+	ctx = remote_numa_eth_donor_init(mem);
 	if (ctx)
 	{
 		kthread = kthread_run(advert_thread, NULL, "remote_numa_advert");
 		if (IS_ERR(kthread)) {
 			printk(KERN_ERR "REMOTE_NUMA donor advert kthread failed\n");
 			remote_numa_transport_ctx_destroy(ctx->trprt_ctx);
+			remote_numa_clean_mem_mgr(mem);
 			return PTR_ERR(kthread);
 		}
 	}
 	else
 	{
 		printk(KERN_ERR "REMOTE_NUMA donor bad init.");
+		remote_numa_clean_mem_mgr(mem);
 		return -ENOMEM;
 	}
 	return 0;
@@ -88,12 +82,14 @@ remote_numa_donor_node_init(void)
 static void __exit
 remote_numa_donor_node_exit(void)
 {
-	printk(KERN_INFO "REMOTE_NUMA donor cleanup\n");
+	remote_numa_worker_pool_set_reject(true);
 
 	if (kthread)
 		kthread_stop(kthread);
-	
+
+	remote_numa_worker_pool_stop();
 	remote_numa_clean_donor_trprt_if(ctx);
+	remote_numa_clean_mem_mgr(mem);
 }
 
 module_init(remote_numa_donor_node_init);

--- a/drivers/staging/remote_numa/eth_transport.c
+++ b/drivers/staging/remote_numa/eth_transport.c
@@ -22,26 +22,14 @@
 #include "eth_transport.h"
 #include "protocol.h"
 #include "transport.h"
+#include "worker_pool.h"
 
 #define REMOTE_NUMA_IF_NAME "eth0"
 #define REMOTE_NUMA_MAX_DATA_LEN 1500
 
-
-
-#define REMOTE_NUMA_SKB_SIZE(_size, _additional)				\
-	(sizeof(struct ethhdr) +						\
-	 (((_size + (_additional)) <					\
-	   (ETH_ZLEN - sizeof(struct ethhdr))) ?		\
-	  (ETH_ZLEN - sizeof(struct ethhdr)) :		\
-	  (_size + (_additional))) +					\
-	 NET_IP_ALIGN)
-
-#define REMOTE_NUMA_SKB_SIZE_FOR_TYPE(_T_, __additional)				\
-	REMOTE_NUMA_SKB_SIZE(sizeof(_T_), __additional)
-
-#define REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr, type, err_label)			\
+#define REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr, type, err_label, __mem)			\
 	do {								\
-		(ptr)->trprt_ctx = remote_numa_make_trprt_ctx();	\
+		(ptr)->trprt_ctx = remote_numa_make_trprt_ctx(__mem);	\
 		if (!(ptr)->trprt_ctx) {				\
 			printk(KERN_ERR					\
 			       "REMOTE_NUMA: alloc generic ctx failed\n"); \
@@ -80,11 +68,34 @@ typedef struct
 	u8 return_mac_addr[ETH_ALEN];
 } remote_numa_eth_priv_ret_info_t;
 
-static void* setup_skb(struct sk_buff *txskb, size_t data_len)
+static void free_rx_buff(void *buff)
+{
+	struct sk_buff *b = buff;
+	kfree_skb(b);
+}
+
+static custom_net_hook_ret_t eth_skb_handler(struct sk_buff *skb)
+{
+	if (skb->protocol != REMOTE_NUMA_ETHERTYPE)
+		return custom_net_hook_not_consumed;
+
+	if (remote_numa_submit_frame(skb)) {
+		free_rx_buff(skb);
+		return custom_net_hook_consumed_with_error;
+	}
+
+	return custom_net_hook_consumed;
+}
+
+static void* setup_skb(struct sk_buff *txskb, size_t payload_len)
 {
 	skb_reserve(txskb, NET_IP_ALIGN + sizeof(struct ethhdr));
-	data_len = data_len < ETH_ZLEN ? ETH_ZLEN : data_len;
-	void *data  = skb_put(txskb, data_len);
+
+	// Ethernet requires minimum 46-byte payload
+	size_t padded_len = payload_len < 46 ? 46 : payload_len;
+
+	void *data = skb_put(txskb, padded_len);
+
 	skb_push(txskb, sizeof(struct ethhdr));
 	skb_reset_mac_header(txskb);
 
@@ -93,9 +104,10 @@ static void* setup_skb(struct sk_buff *txskb, size_t data_len)
 
 static void alloc_tx_buffer(size_t payload_len, void **obj, void**payload_start)
 {
-	struct sk_buff *txskb = alloc_skb(
-	    REMOTE_NUMA_SKB_SIZE(payload_len, 0),
-	    GFP_ATOMIC);
+	size_t alloc_len = (sizeof(struct ethhdr) + ((payload_len <
+		(ETH_ZLEN - sizeof(struct ethhdr))) ? (ETH_ZLEN - sizeof(struct ethhdr)) :
+		 (payload_len))) + NET_IP_ALIGN;
+	struct sk_buff *txskb = alloc_skb(alloc_len, GFP_KERNEL);
 
 	if (!txskb)
 	{
@@ -103,8 +115,7 @@ static void alloc_tx_buffer(size_t payload_len, void **obj, void**payload_start)
 		*payload_start = NULL;
 		return;
 	}
-	*payload_start = setup_skb(txskb,
-		REMOTE_NUMA_SKB_SIZE(payload_len, 0));
+	*payload_start = setup_skb(txskb, payload_len);
 	*obj = txskb;
 }
 
@@ -113,7 +124,6 @@ static void* eth_priv_return_info(remote_numa_advert_t *advert)
 	remote_numa_eth_advert_t *eth_ad = (remote_numa_eth_advert_t*)advert;
 	remote_numa_eth_priv_ret_info_t *info =
 		kmalloc(sizeof(*info), GFP_KERNEL);
-
 	if (info)
 	{
 		ether_addr_copy(info->return_mac_addr, eth_ad->src_mac_addr);
@@ -135,12 +145,11 @@ void remote_numa_clean_donor_trprt_if(remote_numa_donor_trprt_if_t *iface)
 	if (!iface)
 		return;
 
+	if (iface->trprt_ctx->trprt_ctx)
+		kfree(iface->trprt_ctx->trprt_ctx);
+
 	if (iface->trprt_ctx)
-	{
-		kfree(iface->trprt_ctx);
-	}
-	remote_numa_transport_ctx_destroy(iface->trprt_ctx);
-	
+		remote_numa_transport_ctx_destroy(iface->trprt_ctx);
 }
 
 void remote_numa_clean_main_trprt_if(remote_numa_main_trprt_if_t *iface)
@@ -154,11 +163,11 @@ void remote_numa_clean_main_trprt_if(remote_numa_main_trprt_if_t *iface)
 	if (!iface)
 		return;
 
+	if (iface->trprt_ctx->trprt_ctx)
+		kfree(iface->trprt_ctx->trprt_ctx);
+
 	if (iface->trprt_ctx)
-	{
-		kfree(iface->trprt_ctx);
-	}
-	remote_numa_transport_ctx_destroy(iface->trprt_ctx);
+		remote_numa_transport_ctx_destroy(iface->trprt_ctx);
 }
 
 static u32 advert_to_node_id(remote_numa_advert_t *ad)
@@ -227,6 +236,17 @@ static remote_numa_send_ret_t tx_msg(remote_numa_trprt_ctx_t *trprt_ctx,
 	return send_msg(trprt_ctx->trprt_ctx, msg, return_info);
 }
 
+static void prepare_rx_buff(void *rx_buff, void **payload)
+{
+
+	struct sk_buff *skb = rx_buff;
+	u8 *pay = skb_mac_header_was_set(skb) ?
+		skb_mac_header(skb) + ETH_HLEN :
+		skb->data + ETH_HLEN;
+
+	*payload = pay;
+}
+
 static remote_numa_send_ret_t remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t *trprt_ctx)
 {
 	/* The error path should not unlock if we did not
@@ -234,18 +254,19 @@ static remote_numa_send_ret_t remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t 
  	 */
 	bool took_rcu = false;
 	remote_numa_send_ret_t ret = 0;
-	struct sk_buff *txskb = alloc_skb(
-	    REMOTE_NUMA_SKB_SIZE_FOR_TYPE(remote_numa_eth_advert_t, 0),
-	    GFP_ATOMIC);
+	struct sk_buff *txskb = NULL;
+	remote_numa_eth_advert_t *payload_start = NULL;
+	void **v_txskb = (void**)&txskb;
+	void **v_payload_start = (void**)&payload_start;
+
+	alloc_tx_buffer(sizeof(*payload_start), v_txskb, v_payload_start);
+	
 	if (!txskb)
 	{
 		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_send_bad_alloc, 1);
 		goto done;
 	}
 	
-	remote_numa_eth_advert_t *payload_start =
-	    setup_skb(txskb,
-	        REMOTE_NUMA_SKB_SIZE_FOR_TYPE(remote_numa_eth_advert_t, 0));
 	payload_start->generic_advert.max_frame_len =
 	    ((struct remote_numa_eth_trprt_ctx *)trprt_ctx->trprt_ctx)->max_data_len;
 	
@@ -282,7 +303,6 @@ done:
 static remote_numa_receive_ret_t remote_numa_eth_rx_mem_query
     (remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_query_t *query)
 {
-	printk("rx a mem query");
 	return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 0);
 }
 
@@ -298,7 +318,7 @@ static remote_numa_receive_ret_t remote_numa_eth_rx_mem_resp
 	return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 0);
 }
 
-remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(skb_handler_t handler)
+remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(remote_numa_mem_mgr_t *mem)
 {
 	get_random_bytes(&net_secret, sizeof(net_secret));
 
@@ -309,17 +329,20 @@ remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(skb_handler_t handler)
 		goto err;
 	}
 
+	ptr->prepare_rx_buff = prepare_rx_buff;
+	ptr->free_rx_buff = free_rx_buff;
 	ptr->tx_advert = remote_numa_eth_tx_advert;
 	ptr->rx_mem_query = remote_numa_eth_rx_mem_query;
 	ptr->tx_mem_resp = remote_numa_eth_tx_mem_resp;
 
-	REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr, struct remote_numa_eth_trprt_ctx, err);
+	REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr,
+		struct remote_numa_eth_trprt_ctx, err, mem);
 	struct remote_numa_eth_trprt_ctx *eth_ctx = ptr->trprt_ctx->trprt_ctx;
 	eth_ctx->if_name = REMOTE_NUMA_IF_NAME;
 	eth_ctx->max_data_len =
 		REMOTE_NUMA_MAX_DATA_LEN - sizeof(remote_numa_msg_hdr_t);
 
-	rcu_assign_pointer(custom_net_hook, handler);
+	rcu_assign_pointer(custom_net_hook, eth_skb_handler);
 
 	return ptr;
 err:
@@ -328,7 +351,7 @@ err:
 	return NULL;
 }
 
-remote_numa_main_trprt_if_t *remote_numa_eth_main_init(skb_handler_t handler)
+remote_numa_main_trprt_if_t *remote_numa_eth_main_init(void)
 {
 	remote_numa_main_trprt_if_t *ptr = kzalloc(sizeof(*ptr), GFP_KERNEL);
 	if (!ptr)
@@ -337,6 +360,8 @@ remote_numa_main_trprt_if_t *remote_numa_eth_main_init(skb_handler_t handler)
 		goto err;
 	}
 
+	ptr->prepare_rx_buff = prepare_rx_buff;
+	ptr->free_rx_buff = free_rx_buff;
 	ptr->alloc_tx_buffer = alloc_tx_buffer;
 	ptr->remote_numa_node_id = advert_to_node_id;
 	ptr->priv_return_info = eth_priv_return_info;
@@ -344,13 +369,14 @@ remote_numa_main_trprt_if_t *remote_numa_eth_main_init(skb_handler_t handler)
 	ptr->rx_mem_resp = remote_numa_eth_rx_mem_resp;
 	ptr->tx_msg = tx_msg;
 
-	REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr, struct remote_numa_eth_trprt_ctx ,err);
+	REMOTE_NUMA_ALLOC_TRPRT_CTX(ptr,
+		struct remote_numa_eth_trprt_ctx, err, NULL);
 	struct remote_numa_eth_trprt_ctx *eth_ctx = ptr->trprt_ctx->trprt_ctx;
 	eth_ctx->if_name = REMOTE_NUMA_IF_NAME;
 	eth_ctx->max_data_len =
 		REMOTE_NUMA_MAX_DATA_LEN - sizeof(remote_numa_msg_hdr_t);
 
-	rcu_assign_pointer(custom_net_hook, handler);
+	rcu_assign_pointer(custom_net_hook, eth_skb_handler);
 
 	return ptr;
 err:

--- a/drivers/staging/remote_numa/eth_transport.h
+++ b/drivers/staging/remote_numa/eth_transport.h
@@ -10,6 +10,7 @@
 
 #include <linux/skbuff.h>
 
+#include "memory.h"
 #include "protocol.h"
 #include "transport.h"
 
@@ -17,10 +18,10 @@
 
 typedef custom_net_hook_ret_t (*skb_handler_t)(struct sk_buff *);
 
-remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(skb_handler_t handler);
+remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(remote_numa_mem_mgr_t *mem);
 void remote_numa_clean_donor_trprt_if(remote_numa_donor_trprt_if_t *iface);
 
-remote_numa_main_trprt_if_t *remote_numa_eth_main_init(skb_handler_t handler);
+remote_numa_main_trprt_if_t *remote_numa_eth_main_init(void );
 void remote_numa_clean_main_trprt_if(remote_numa_main_trprt_if_t *iface);
 
 #endif

--- a/drivers/staging/remote_numa/main_node.c
+++ b/drivers/staging/remote_numa/main_node.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2025 Trevor Kemp
  */
 
+#include <linux/compiler.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -15,40 +16,24 @@
 
 #include "eth_transport.h"
 #include "protocol.h"
+#include "worker_pool.h"
+
+#define WORKER_POOL_SIZE 4
 
 remote_numa_main_trprt_if_t *ctx = NULL;
 
-static custom_net_hook_ret_t
-main_node_skb_handler(struct sk_buff *skb)
+static remote_numa_receive_ret_t rx_wrapper(void *frame)
 {
-	/*
- 	 * TODO we should really be doing any work on a worker thread
- 	 * and not in the unterrupt context.
- 	 */  
-	if (skb->protocol != REMOTE_NUMA_ETHERTYPE)
-		return custom_net_hook_not_consumed;
-
-	u8 *payload;
-	if (skb_mac_header_was_set(skb))
-		payload = skb_mac_header(skb) + ETH_HLEN;
-	else
-		payload = skb->data + ETH_HLEN;
-
-	remote_numa_receive_ret_t tmp_ret = remote_numa_main_rx(ctx, payload);
-	kfree_skb(skb);
-
-	if (tmp_ret)
-	{
-		return custom_net_hook_consumed_with_error;
-	}
-
-	return custom_net_hook_consumed;
+	void *payload = NULL;
+	ctx->prepare_rx_buff(frame, &payload);
+	return remote_numa_main_rx(ctx, frame, payload);
 }
 
 static int __init
 remote_numa_main_node_init(void)
 {
-	ctx = remote_numa_eth_main_init(main_node_skb_handler);
+	remote_numa_worker_pool_init(rx_wrapper, WORKER_POOL_SIZE);
+	ctx = remote_numa_eth_main_init();
 	if (!ctx)
 	{
 		printk(KERN_ERR "REMOTE_NUMA main bad init.");
@@ -60,8 +45,9 @@ remote_numa_main_node_init(void)
 static void __exit
 remote_numa_main_node_exit(void)
 {
-	custom_net_hook = NULL;
-	printk(KERN_INFO "Unregistered custom handler\n");
+	remote_numa_worker_pool_set_reject(true);
+	remote_numa_worker_pool_stop();
+	remote_numa_clean_main_trprt_if(ctx);
 }
 
 module_init(remote_numa_main_node_init);

--- a/drivers/staging/remote_numa/memory.c
+++ b/drivers/staging/remote_numa/memory.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+* memory.c - Remote Numa memory management.
+*
+* Copyright (C) 2025 Trevor Kemp
+*/
+
+#include <linux/slab.h>
+#include <linux/vmalloc.h>
+
+#include "memory.h"
+
+remote_numa_mem_mgr_t *remote_numa_create_mem_mgr(size_t len)
+{
+	remote_numa_mem_mgr_t *mgr = kmalloc(sizeof(*mgr), GFP_KERNEL);
+	if (!mgr)
+		return NULL;
+
+	mgr->mem.buffer_len = len;
+	mgr->mem.large_buffer = vmalloc(len);
+
+	if (!mgr->mem.large_buffer)
+	{
+		kfree(mgr);
+		return NULL;
+	}
+
+	return mgr;
+}
+
+void remote_numa_clean_mem_mgr(remote_numa_mem_mgr_t *mgr)
+{
+	if (!mgr)
+		return;
+
+	vfree(mgr->mem.large_buffer);
+	kfree(mgr);
+}
+

--- a/drivers/staging/remote_numa/memory.h
+++ b/drivers/staging/remote_numa/memory.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * memory.h - Remote Numa memory manager.
+ *
+ * Copyright (C) 2025 Trevor Kemp
+ */
+
+#ifndef _REMOTE_NUMA_MEMORY_H
+#define _REMOTE_NUMA_MEMORY_H
+
+#include "memory.h"
+
+typedef struct
+{
+	void *large_buffer;
+	size_t buffer_len;
+} remote_numa_mem_buff_t;
+
+typedef struct
+{
+	remote_numa_mem_buff_t mem;
+} remote_numa_mem_mgr_t;
+
+remote_numa_mem_mgr_t *remote_numa_create_mem_mgr(size_t len);
+
+void remote_numa_clean_mem_mgr(remote_numa_mem_mgr_t *mgr);
+
+#endif
+

--- a/drivers/staging/remote_numa/transport.c
+++ b/drivers/staging/remote_numa/transport.c
@@ -14,7 +14,7 @@
 
 #define REMOTE_NUMA_SUPPORTED_PROTO  remote_numa_protocol_0_1
 
-remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(void)
+remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(remote_numa_mem_mgr_t *mem)
 {
 	remote_numa_trprt_ctx_t *ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
 	if (!ctx)
@@ -24,6 +24,7 @@ remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(void)
 
 	spin_lock_init(&ctx->hash_write_lock);
 
+	ctx->mem = mem;
 	ctx->trprt_ctx = NULL;
 	return ctx;
 }
@@ -46,39 +47,55 @@ void remote_numa_transport_ctx_destroy(remote_numa_trprt_ctx_t *ctx)
 }
 
 remote_numa_receive_ret_t remote_numa_main_rx(
-	remote_numa_main_trprt_if_t *main_if, void *rx_data)
+	remote_numa_main_trprt_if_t *main_if, void *rx_data, void *payload)
 {
-	remote_numa_msg_hdr_t *hdr = rx_data;
+	remote_numa_receive_ret_t ret = 0;
+
+	remote_numa_msg_hdr_t *hdr = payload;
 	if (hdr->version != REMOTE_NUMA_SUPPORTED_PROTO)
 	{
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		goto done;
 	}
 
 	switch(hdr->type)
 	{
 	case remote_numa_eth_advert:
-		return remote_numa_rx_advert(main_if, rx_data);
+		ret = remote_numa_rx_advert(main_if, payload);
+		goto done;
 	default:
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		goto done;
 	}
+done:
+	main_if->free_rx_buff(rx_data);	
+	return ret;
 }
 
 remote_numa_receive_ret_t remote_numa_donor_rx(
-	remote_numa_donor_trprt_if_t *donor_if, void *rx_data)
+	remote_numa_donor_trprt_if_t *donor_if, void *rx_data, void *payload)
 {
-	remote_numa_msg_hdr_t *hdr = rx_data;
+	remote_numa_receive_ret_t ret = 0;
+
+	remote_numa_msg_hdr_t *hdr = payload;
 	if (hdr->version != REMOTE_NUMA_SUPPORTED_PROTO)
 	{
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		goto done;
 	}
 
 	switch(hdr->type)
 	{
 	case remote_numa_mem_query:
-		return remote_numa_rx_mem_query(donor_if, rx_data);
+		ret = remote_numa_rx_mem_query(donor_if, rx_data);
+		goto done;
 	default:
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		goto done;
 	}
+done:
+	donor_if->free_rx_buff(rx_data);	
+	return ret;
 }
 
 remote_numa_receive_ret_t remote_numa_rx_advert(
@@ -107,7 +124,7 @@ remote_numa_receive_ret_t remote_numa_rx_advert(
 		goto success;
 	}
 
-	node = kmalloc(sizeof(*node), GFP_ATOMIC);
+	node = kmalloc(sizeof(*node), GFP_KERNEL);
 
 	if (!node)
 		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_alloc, 1);

--- a/drivers/staging/remote_numa/transport.h
+++ b/drivers/staging/remote_numa/transport.h
@@ -11,6 +11,7 @@
 #include <linux/hashtable.h>
 #include <linux/types.h>
 
+#include "memory.h"
 #include "protocol.h"
 
 /* Create a return val for base + transport */
@@ -71,6 +72,7 @@ typedef struct
 
 typedef struct
 {
+	remote_numa_mem_mgr_t *mem;
 	DECLARE_HASHTABLE(node_table, REMOTE_NUMA_HASH_TABLE_ORDER);
 	void *trprt_ctx;
 	spinlock_t hash_write_lock;
@@ -78,6 +80,8 @@ typedef struct
 
 typedef struct
 {
+	void (*free_rx_buff)(void *);
+	void (*prepare_rx_buff)(void *rx_buff, void **payload);
 	remote_numa_send_ret_t (*tx_advert)(remote_numa_trprt_ctx_t *trprt_ctx);
 	remote_numa_receive_ret_t (*rx_mem_query)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_query_t *query);
 	remote_numa_send_ret_t (*tx_mem_resp)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp);
@@ -91,6 +95,8 @@ typedef struct
 	u32 (*remote_numa_node_id)(remote_numa_advert_t *);
 	void* (*priv_return_info)(remote_numa_advert_t *);
 	void (*free_priv_return_info)(void*);
+	void (*free_rx_buff)(void *);
+	void (*prepare_rx_buff)(void *rx_buff, void **payload);
 	void (*alloc_tx_buffer)(size_t payload_len,
 		void **obj, void**payload_start);
 	remote_numa_send_ret_t (*tx_msg)(remote_numa_trprt_ctx_t *trprt_ctx,
@@ -101,15 +107,15 @@ typedef struct
 	remote_numa_trprt_ctx_t *trprt_ctx;
 } remote_numa_main_trprt_if_t;
 
-remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(void);
+remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(remote_numa_mem_mgr_t *mem);
 
 void remote_numa_transport_ctx_destroy(remote_numa_trprt_ctx_t *ctx);
 
 remote_numa_receive_ret_t remote_numa_main_rx(
-	remote_numa_main_trprt_if_t *main_if, void *rx_data);
+	remote_numa_main_trprt_if_t *main_if, void *rx_data, void *payload);
 
 remote_numa_receive_ret_t remote_numa_donor_rx(
-	remote_numa_donor_trprt_if_t *donor_if, void *rx_data);
+	remote_numa_donor_trprt_if_t *donor_if, void *rx_data, void *payload);
 
 remote_numa_receive_ret_t remote_numa_rx_advert(
 	remote_numa_main_trprt_if_t *main_if,

--- a/drivers/staging/remote_numa/worker_pool.c
+++ b/drivers/staging/remote_numa/worker_pool.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * transport.h - Remote Numa transport interface.
+ *
+ * Copyright (C) 2025 Trevor Kemp
+ */
+
+#include <linux/kthread.h>
+#include <linux/llist.h>
+#include <linux/slab.h>
+#include <linux/wait.h>
+#include <linux/skbuff.h>
+#include <linux/netdevice.h>
+#include <linux/etherdevice.h>
+
+#include "worker_pool.h"
+
+struct worker_job {
+	struct llist_node llnode;
+	void *frame;
+};
+
+static struct llist_head job_list;
+static struct task_struct **workers;
+static wait_queue_head_t wq;
+static int worker_count;
+static rx_func_t handler_fn;
+static bool rejecting_work;
+
+remote_numa_receive_ret_t remote_numa_submit_frame(void *frame)
+{
+	if (READ_ONCE(rejecting_work))
+		return REMOTE_NUMA_TRPRT_RET(
+			remote_numa_receive_err_unknown, 10);
+
+	struct worker_job *job = kmalloc(sizeof(*job), GFP_ATOMIC);
+	if (!job)
+		return REMOTE_NUMA_TRPRT_RET(
+			remote_numa_receive_bad_alloc, 10);
+
+	job->frame = frame;
+	llist_add(&job->llnode, &job_list);
+	wake_up_interruptible_nr(&wq, 1);
+	return 0;
+}
+
+static int worker_fn(void *)
+{
+	struct llist_node *pending;
+	struct worker_job *job;
+
+	while (!kthread_should_stop()) {
+		wait_event_interruptible(wq,
+			!llist_empty(&job_list) ||
+			kthread_should_stop());
+
+		if (kthread_should_stop())
+			break;
+
+		pending = llist_del_all(&job_list);
+		while (pending) {
+			job = llist_entry(pending,
+				struct worker_job, llnode);
+			pending = pending->next;
+
+			handler_fn(job->frame);
+			kfree(job);
+		}
+	}
+
+	return 0;
+}
+
+int remote_numa_worker_pool_init(rx_func_t handler, int num_workers)
+{
+	WRITE_ONCE(rejecting_work, false);
+	handler_fn = handler;
+	worker_count = num_workers;
+
+	init_llist_head(&job_list);
+	init_waitqueue_head(&wq);
+
+	workers = kmalloc_array(worker_count,
+		sizeof(*workers), GFP_KERNEL);
+	if (!workers)
+		return -ENOMEM;
+
+	for (int i = 0; i < worker_count; i++) {
+		workers[i] = kthread_run(worker_fn, NULL,
+			"remote_numa_worker_%d", i);
+		if (IS_ERR(workers[i]))
+			return PTR_ERR(workers[i]);
+	}
+
+	return 0;
+}
+
+void remote_numa_worker_pool_stop(void)
+{
+	WRITE_ONCE(rejecting_work, true);
+	for (int i = 0; i < worker_count; i++) {
+		if (workers[i])
+			kthread_stop(workers[i]);
+	}
+	kfree(workers);
+	workers = NULL;
+}
+
+void remote_numa_worker_pool_set_reject(bool reject)
+{
+	WRITE_ONCE(rejecting_work, reject);
+}
+

--- a/drivers/staging/remote_numa/worker_pool.h
+++ b/drivers/staging/remote_numa/worker_pool.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * transport.h - Remote Numa transport interface.
+ *
+ * Copyright (C) 2025 Trevor Kemp
+ */
+
+#ifndef _REMOTE_NUMA_WORKER_POOL_H
+#define _REMOTE_NUMA_WORKER_POOL_H
+
+#include "transport.h"
+
+typedef remote_numa_receive_ret_t (*rx_func_t)(void *);
+
+int remote_numa_worker_pool_init(rx_func_t handler, int num_workers);
+void remote_numa_worker_pool_stop(void);
+remote_numa_receive_ret_t remote_numa_submit_frame(void *frame);
+void remote_numa_worker_pool_set_reject(bool reject);
+
+#endif
+


### PR DESCRIPTION
Small cleanup, use worker threads and don't execute directly out of IRQ context. All frame types are abstract, except inside the specific transport layer.