### PR TITLE
convert to standard error codes.

### DIFF
--- a/drivers/staging/remote_numa/donor_node.c
+++ b/drivers/staging/remote_numa/donor_node.c
@@ -31,7 +31,7 @@ static struct task_struct *kthread = NULL;
 static remote_numa_donor_trprt_if_t *ctx = NULL;
 static struct remote_numa_mem_mgr *mem;
 
-static remote_numa_receive_ret_t rx_wrapper(void *frame)
+static int rx_wrapper(void *frame)
 {
 	void *payload = NULL;
 	ctx->prepare_rx_buff(frame, &payload);

--- a/drivers/staging/remote_numa/eth_transport.c
+++ b/drivers/staging/remote_numa/eth_transport.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2025 Trevor Kemp
  */
 
+#include <linux/errno.h>
 #include <linux/etherdevice.h> 
 #include <linux/hashtable.h>
 #include <linux/if.h> 
@@ -129,7 +130,7 @@ static void alloc_tx_buffer(size_t payload_len, void **obj, void**payload_start)
 	*obj = txskb;
 }
 
-static remote_numa_send_ret_t eth_priv_return_info(
+static int eth_priv_return_info(
 	void *trprt_ctx,
 	remote_numa_main_return_info_t *info)
 {
@@ -137,7 +138,7 @@ static remote_numa_send_ret_t eth_priv_return_info(
 	struct net_device *dev = dev_get_by_name_rcu(&init_net, eth_ctx->if_name);
 	if (!dev)
 	{
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_send_no_if, 3);
+		return -ENODEV;
 	}
 	ether_addr_copy(info->abstract_info, dev->dev_addr);
 
@@ -227,7 +228,7 @@ static u32 rx_skb_to_node_id(void *rx_data, void *payload)
 	return mac_to_node_id(eth->h_source);
 }
 
-static remote_numa_send_ret_t send_msg(struct remote_numa_eth_trprt_ctx *ctx,
+static int send_msg(struct remote_numa_eth_trprt_ctx *ctx,
 				       struct sk_buff *skb,
 				       const u8* dst_mac)
 {
@@ -235,7 +236,7 @@ static remote_numa_send_ret_t send_msg(struct remote_numa_eth_trprt_ctx *ctx,
  	*  list of skb and acquires the lock one time.
  	*/
 
-	remote_numa_send_ret_t ret = 0;
+	int ret = 0;
 
 	struct ethhdr *eth = eth_hdr(skb);
 	ether_addr_copy(eth->h_dest, dst_mac);
@@ -249,7 +250,7 @@ static remote_numa_send_ret_t send_msg(struct remote_numa_eth_trprt_ctx *ctx,
 	struct net_device *dev = dev_get_by_name_rcu(&init_net, ctx->if_name);
 	if (!dev)
 	{
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_send_no_if, 1);
+		ret = -ENODEV;
 		goto done;
 	}
 
@@ -264,7 +265,7 @@ static remote_numa_send_ret_t send_msg(struct remote_numa_eth_trprt_ctx *ctx,
  		 * to carefully handle the case of segmented data drops.
  		 */ 
 		skb = NULL;
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_send_bad_xmit, 1);
+		ret = -EIO;
 		goto done;
 	}
 	skb = NULL;
@@ -276,7 +277,7 @@ done:
 	return ret;
 }
 
-static remote_numa_send_ret_t tx_msg(remote_numa_trprt_ctx_t *trprt_ctx,
+static int tx_msg(remote_numa_trprt_ctx_t *trprt_ctx,
 	void *return_info, void *msg)
 {
 	return send_msg(trprt_ctx->trprt_ctx, msg, return_info);
@@ -295,13 +296,13 @@ static void prepare_rx_buff(void *rx_buff, void **payload)
 	*payload = pay;
 }
 
-static remote_numa_send_ret_t remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t *trprt_ctx)
+static int remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t *trprt_ctx)
 {
 	/* The error path should not unlock if we did not
  	 * acquire the lock in this function.
  	 */
 	bool took_rcu = false;
-	remote_numa_send_ret_t ret = 0;
+	int ret = 0;
 	struct sk_buff *txskb = NULL;
 	remote_numa_advert_t *payload_start = NULL;
 	void **v_txskb = (void**)&txskb;
@@ -311,7 +312,7 @@ static remote_numa_send_ret_t remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t 
 	
 	if (!txskb)
 	{
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_send_bad_alloc, 1);
+		ret = -ENOMEM;
 		goto done;
 	}
 	
@@ -334,7 +335,7 @@ static remote_numa_send_ret_t remote_numa_eth_tx_advert(remote_numa_trprt_ctx_t 
 		dev_get_by_name_rcu(&init_net, ctx->if_name);
 	if (!dev)
 	{
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_send_no_if, 2);
+		ret = -ENODEV;
 		goto done;
 	}
 	ether_addr_copy(payload_start->return_info.abstract_info, dev->dev_addr);
@@ -348,22 +349,22 @@ done:
 	return ret;
 }
 
-static remote_numa_receive_ret_t remote_numa_eth_rx_mem_query
+static int remote_numa_eth_rx_mem_query
     (remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_query_t *query)
 {
-	return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 0);
+	return -EOPNOTSUPP;
 }
 
-static remote_numa_send_ret_t remote_numa_eth_tx_mem_resp
+static int remote_numa_eth_tx_mem_resp
     (remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp)
 {
-	return REMOTE_NUMA_TRPRT_RET(remote_numa_send_err_unknown, 0);
+	return -EOPNOTSUPP;
 }
 
-static remote_numa_receive_ret_t remote_numa_eth_rx_mem_resp
+static int remote_numa_eth_rx_mem_resp
     (remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp)
 {
-	return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 0);
+	return -EOPNOTSUPP;
 }
 
 remote_numa_donor_trprt_if_t *remote_numa_eth_donor_init(struct remote_numa_mem_mgr *mem)

--- a/drivers/staging/remote_numa/main_node.c
+++ b/drivers/staging/remote_numa/main_node.c
@@ -28,7 +28,7 @@ remote_numa_main_trprt_if_t *ctx = NULL;
 remote_numa_client_cache_t *client_cache = NULL;
 EXPORT_SYMBOL(client_cache);
 
-static remote_numa_receive_ret_t rx_wrapper(void *frame)
+static int rx_wrapper(void *frame)
 {
 	void *payload = NULL;
 	ctx->prepare_rx_buff(frame, &payload);

--- a/drivers/staging/remote_numa/remote_numa_test.c
+++ b/drivers/staging/remote_numa/remote_numa_test.c
@@ -38,7 +38,7 @@
 
 #define REMOTE_NUMA_STRESS_TEST 1
 #define REMOTE_NUMA_STRESS_MAX_CONCURRENT_OPS 4
-#define REMOTE_NUMA_STRESS_MINUTES 120
+#define REMOTE_NUMA_STRESS_MINUTES 5
 #define REMOTE_NUMA_STRESS_THREADS 5
 
 /* Burst size for churn/refault/free operations in the main stress loop. */

--- a/drivers/staging/remote_numa/transport.c
+++ b/drivers/staging/remote_numa/transport.c
@@ -82,7 +82,7 @@ static void alloc_tx_buffer(main_xfer_state_t *xfer,
 			payload_start);
 }
 
-static remote_numa_send_ret_t tx_msg(
+static int tx_msg(
 	main_xfer_state_t *xfer, void *msg)
 {
 	if (xfer->is_main_node)
@@ -106,22 +106,22 @@ static u16 xfer_state_max_payload(
 		return xfer->donor_trprt->get_max_payload_len();
 }
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch(
+static int remote_numa_rx_mem_pg_refetch(
 	struct remote_numa_donor_trprt_if *donor_if,
 	remote_numa_mem_refetch_t *refetch,
 	u32 main_node_id);
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_alloc_from(
+static int remote_numa_rx_mem_alloc_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_alloc_t *alloc,
 	u32 main_node_id);
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer_from(
+static int remote_numa_rx_mem_pg_sync_xfer_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_pg_xfer_t *xfer,
 	u32 main_node_id);
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_from(
+static int remote_numa_rx_mem_pg_free_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_free_t *pg_free,
 	u32 main_node_id);
@@ -438,14 +438,14 @@ static void remote_numa_send_all_segments(main_xfer_state_t *xfer, u16 seg_len)
 	}
 }
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch(
+static int remote_numa_rx_mem_pg_refetch(
 	struct remote_numa_donor_trprt_if *donor_if,
 	remote_numa_mem_refetch_t *refetch,
 	u32 main_node_id)
 {
 	struct remote_numa_mem_mgr *mgr = donor_if->trprt_ctx->mem;
 	if (!mgr)
-		return remote_numa_receive_err_unknown;
+		return -EIO;
 
 	void *page_ptr;
 	remote_numa_page_t *rn_pg;
@@ -453,14 +453,14 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch(
 	if (remote_numa_mem_lookup_page(mgr, refetch->donor_pg_cookie,
 	                                 &page_ptr, &rn_pg) != 0)
 	{
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 	}
 	cached_pg = &rn_pg->cached_pg;
 
 	struct page *pg = virt_to_page(page_ptr);
 	if (!pg)
 	{
-		return remote_numa_receive_err_unknown;
+		return -EIO;
 	}
 
 	remote_numa_node_t *main_node = __remote_numa_get_node_locking(
@@ -469,12 +469,12 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch(
 		main_node_id);
 	if (!main_node)
 	{
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 	}
 
 	main_xfer_state_t *xfer = kzalloc(sizeof(*xfer), GFP_KERNEL);
 	if (!xfer)
-		return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
 
 	// TODO, this is super confusing, need to rename some fields.
@@ -517,10 +517,10 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch(
 		      sizeof(remote_numa_mem_pg_xfer_t);
 	remote_numa_send_all_segments(xfer, seg_len);
 
-	return remote_numa_receive_success;
+	return 0;
 }
 
-remote_numa_send_ret_t remote_numa_transport_alloc_page_async(
+int remote_numa_transport_alloc_page_async(
 	struct remote_numa_main_trprt_if *trprt,
 	remote_numa_node_t *donor,
 	struct remote_numa_cached_page *cached_target)
@@ -535,7 +535,7 @@ remote_numa_send_ret_t remote_numa_transport_alloc_page_async(
 
 	if (!xfer) {
 		printk(KERN_DEBUG "Could not alloc xfer state.\n");
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 	}
 	refcount_set(&xfer->refcnt, 1);
 
@@ -582,7 +582,7 @@ remote_numa_send_ret_t remote_numa_transport_alloc_page_async(
 		hash_del(&xfer->node);
 		spin_unlock(&hacky_spinlock);
 		xfer_put(xfer);
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 	}
 
 	req->hdr.version = remote_numa_protocol_0_1;
@@ -597,14 +597,14 @@ remote_numa_send_ret_t remote_numa_transport_alloc_page_async(
 		hash_del(&xfer->node);
 		spin_unlock(&hacky_spinlock);
 		xfer_put(xfer);
-		return remote_numa_send_bad_xmit;
+		return -EIO;
 	}
 
 	/* Return immediately - caller must check completion later */
-	return remote_numa_send_success;
+	return 0;
 }
 
-remote_numa_send_ret_t remote_numa_transport_refetch_page_async(
+int remote_numa_transport_refetch_page_async(
 	struct remote_numa_main_trprt_if *trprt,
 	u32 donor_node_id,
 	u64 donor_pg_cookie,
@@ -623,11 +623,11 @@ remote_numa_send_ret_t remote_numa_transport_refetch_page_async(
 	rcu_read_unlock();
 
 	if (!donor)
-		return remote_numa_send_no_if;
+		return -ENODEV;
 
 	main_xfer_state_t *xfer = kzalloc(sizeof(*xfer), GFP_ATOMIC);
 	if (!xfer)
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
 
 	xfer->cached_pg = cached_target;
@@ -664,7 +664,7 @@ remote_numa_send_ret_t remote_numa_transport_refetch_page_async(
 		hash_del(&xfer->node);
 		spin_unlock(&hacky_spinlock);
 		xfer_put(xfer);
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 	}
 
 	refetch->hdr.version       = remote_numa_protocol_0_1;
@@ -679,31 +679,31 @@ remote_numa_send_ret_t remote_numa_transport_refetch_page_async(
 		hash_del(&xfer->node);
 		spin_unlock(&hacky_spinlock);
 		xfer_put(xfer);
-		return remote_numa_send_bad_xmit;
+		return -EIO;
 	}
 
 	/* Return immediately - caller polls for completion */
-	return remote_numa_send_success;
+	return 0;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer(
+int remote_numa_rx_mem_pg_sync_xfer(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_pg_xfer_t *xfer)
 {
 	return remote_numa_rx_mem_pg_sync_xfer_from(donor_if, xfer, xfer->hdr.donor_cookie);
 }
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer_from(
+static int remote_numa_rx_mem_pg_sync_xfer_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_pg_xfer_t *xfer,
 	u32 main_node_id)
 {
 	struct remote_numa_mem_mgr *mgr = donor_if->trprt_ctx->mem;
 	if (!mgr)
-		return remote_numa_receive_err_unknown;
+		return -EIO;
 
 	if (xfer->payload_len + xfer->seq_num > PAGE_SIZE)
-		return remote_numa_receive_out_of_bounds;
+		return -EOVERFLOW;
 
 	/*
 	 * Best-effort sync: if the receiver cookie is unknown or the page has
@@ -729,7 +729,7 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer_from(
 
 	donor_if->alloc_tx_buffer(sizeof(*ack), &ack_buf, v);
 	if (!ack_buf || !ack)
-		return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
 
 	ack->hdr.version        = remote_numa_protocol_0_1;
 	ack->hdr.type           = remote_numa_mem_sync_ack;
@@ -746,18 +746,18 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer_from(
 		REMOTE_NUMA_HASH_TABLE_ORDER,
 		main_node_id);
 	if (!main_node)
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 
 	int ret = donor_if->tx_msg(donor_if->trprt_ctx,
 	                        main_node->priv_return_info,
 	                        ack_buf) == 0
-	       ? remote_numa_receive_success
-	       : remote_numa_receive_err_unknown;
+	       ? 0
+	       : -EIO;
 
 	return ret;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sat_ack(
+int remote_numa_rx_mem_pg_sat_ack(
 	struct remote_numa_main_trprt_if *main_if,
 	remote_numa_mem_satisfaction_t *ack)
 {
@@ -769,13 +769,13 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_sat_ack(
 	 *   main side has already timed out or retired the xfer.
 	 */
 	if (!xfer) {
-		return remote_numa_receive_success;
+		return 0;
 	}
 	if (ack->hack != xfer->hack) {
 		pr_debug("remote_numa: sat_ack hack mismatch main_cookie=%llu xfer_hack=%d ack_hack=%d\n",
 			 ack->main_pg_cookie, xfer->hack, ack->hack);
 		xfer_put(xfer);
-		return remote_numa_receive_success;
+		return 0;
 	}
 
 	/* mark done and publish donor cookie */
@@ -786,17 +786,17 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_sat_ack(
 	spin_unlock(&hacky_spinlock);
 	wake_up(&xfer->waitq);
 	xfer_put(xfer);
-	return remote_numa_receive_success;
+	return 0;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_ack(
+int remote_numa_rx_mem_pg_sync_ack(
 	struct remote_numa_main_trprt_if *main_if,
 	remote_numa_mem_pg_xfer_ack_t *ack)
 {
 	main_xfer_state_t *xfer = xfer_get(ack->receiver_pg_cookie);
 
 	if (!xfer)
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 
 	bitmap_set(xfer->received_bitmap, ack->bottom_seq_num,
 		ack->top_seq_num - ack->bottom_seq_num);
@@ -806,27 +806,27 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_ack(
 		wake_up(&xfer->waitq);
 	}
 	xfer_put(xfer);
-	return remote_numa_receive_success;
+	return 0;
 }
 
-remote_numa_send_ret_t remote_numa_tx_mem_pg_sync_xfer_async(
+int remote_numa_tx_mem_pg_sync_xfer_async(
 	struct remote_numa_main_trprt_if *main_if,
 	u64 donor_pg_cookie,
 	struct page *pg,
 	struct remote_numa_cached_page *victim)
 {
 	if (!main_if || !pg || !victim)
-		return remote_numa_send_err_unknown;
+		return -EIO;
 	remote_numa_node_t *donor = __remote_numa_get_node_locking(
 		main_if->trprt_ctx->node_table,
 		REMOTE_NUMA_HASH_TABLE_ORDER,
 				victim->known_page->donor_id);
 	if (!donor)
-		return remote_numa_send_no_if;
+		return -ENODEV;
 
 	main_xfer_state_t *xfer = kzalloc(sizeof(*xfer), GFP_ATOMIC);
 	if (!xfer)
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
 
 	spin_lock(&hacky_spinlock);
@@ -857,7 +857,7 @@ remote_numa_send_ret_t remote_numa_tx_mem_pg_sync_xfer_async(
 	remote_numa_send_all_segments(xfer, seg_len);
 
 	/* Return immediately - transfer will complete async */
-	return remote_numa_send_success;
+	return 0;
 }
 
 /* Check if transfer is complete. Returns 0 if done, -EAGAIN if in progress, <0 on error */
@@ -934,16 +934,16 @@ void remote_numa_transport_ctx_destroy(remote_numa_trprt_ctx_t *ctx)
 	kfree(ctx);
 }
 
-remote_numa_receive_ret_t remote_numa_main_rx(
+int remote_numa_main_rx(
 	remote_numa_main_trprt_if_t *main_if, void *rx_data, void *payload)
 {
-	remote_numa_receive_ret_t ret = 0;
+	int ret = 0;
 	u8 hdr_type = 0;
 
 	remote_numa_msg_hdr_t *hdr = payload;
 	if (hdr->version != REMOTE_NUMA_SUPPORTED_PROTO)
 	{
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		ret = -EPROTO;
 		goto done;
 	}
 	hdr_type = hdr->type;
@@ -969,7 +969,7 @@ remote_numa_receive_ret_t remote_numa_main_rx(
 		ret = remote_numa_rx_mem_pg_refetch_sat(main_if, payload);
 		goto done;
 	default:
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		ret = -EBADMSG;
 		printk(KERN_WARNING "error processing pkt... unknown type\n");
 		goto done;
 	}
@@ -983,10 +983,10 @@ done:
 	return ret;
 }
 
-remote_numa_receive_ret_t remote_numa_donor_rx(
+int remote_numa_donor_rx(
 	remote_numa_donor_trprt_if_t *donor_if, void *rx_data, void *payload)
 {
-	remote_numa_receive_ret_t ret = 0;
+	int ret = 0;
 	u32 src_node_id = 0;
 	u8 hdr_type = 0;
 
@@ -996,7 +996,7 @@ remote_numa_receive_ret_t remote_numa_donor_rx(
 	remote_numa_msg_hdr_t *hdr = payload;
 	if (hdr->version != REMOTE_NUMA_SUPPORTED_PROTO)
 	{
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_proto, 1);
+		ret = -EPROTO;
 		goto done;
 	}
 	hdr_type = hdr->type;
@@ -1022,7 +1022,7 @@ remote_numa_receive_ret_t remote_numa_donor_rx(
 		ret = remote_numa_rx_mem_pg_refetch_ack(donor_if, payload);
 		goto done;
 	default:
-		ret = REMOTE_NUMA_TRPRT_RET(remote_numa_receive_mangled_pkt, 1);
+		ret = -EBADMSG;
 		printk(KERN_WARNING "error processing pkt... unknown type\n");
 		goto done;
 	}
@@ -1037,7 +1037,7 @@ done:
 	return ret;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_advert(
+int remote_numa_rx_advert(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_advert_t *advert)
 {
@@ -1051,7 +1051,7 @@ remote_numa_receive_ret_t remote_numa_rx_advert(
 		advert);
 
 	if (!node)
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_alloc, 5);
+		return -ENOMEM;
 	void *tx_buffer_start;
 	remote_numa_mem_query_t *query;
 	void **v_query = (void **)&query;
@@ -1060,7 +1060,7 @@ remote_numa_receive_ret_t remote_numa_rx_advert(
 	if (tx_buffer_start == NULL || query == NULL)
 	{
 		// TODO make file id for each return code to use.
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_send_bad_alloc, 1);
+		return -ENOMEM;
 	}
 	query->hdr.version = remote_numa_protocol_0_1;
 	query->hdr.type = remote_numa_mem_query;
@@ -1075,10 +1075,10 @@ remote_numa_receive_ret_t remote_numa_rx_advert(
  	 */	
 	return main_if->tx_msg(main_if->trprt_ctx,
 		node->priv_return_info, tx_buffer_start) == 0 ?
-		0 : REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 1);
+		0 : -EIO;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_query(
+int remote_numa_rx_mem_query(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_query_t *query)
 {
@@ -1093,7 +1093,7 @@ remote_numa_receive_ret_t remote_numa_rx_mem_query(
 		query);
 
 	if (!node)
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_receive_bad_alloc, 6);
+		return -ENOMEM;
 
 	void *tx_buffer_start;
 	remote_numa_mem_resp_t *resp;
@@ -1103,7 +1103,7 @@ remote_numa_receive_ret_t remote_numa_rx_mem_query(
 	if (tx_buffer_start == NULL || resp == NULL)
 	{
 		// TODO make file id for each return code to use.
-		return REMOTE_NUMA_TRPRT_RET(remote_numa_send_bad_alloc, 2);
+		return -ENOMEM;
 	}
 	resp->hdr.version = remote_numa_protocol_0_1;
 	resp->hdr.type = remote_numa_mem_resp;
@@ -1122,10 +1122,10 @@ remote_numa_receive_ret_t remote_numa_rx_mem_query(
  	 */	
 	return donor_if->tx_msg(donor_if->trprt_ctx,
 		node->priv_return_info, tx_buffer_start) == 0 ?
-		0 : REMOTE_NUMA_TRPRT_RET(remote_numa_receive_err_unknown, 2);
+		0 : -EIO;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_resp(
+int remote_numa_rx_mem_resp(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_resp_t *resp)
 {
@@ -1142,14 +1142,14 @@ remote_numa_receive_ret_t remote_numa_rx_mem_resp(
 	return 0;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_alloc(
+int remote_numa_rx_mem_alloc(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_alloc_t *alloc)
 {
 	return remote_numa_rx_mem_alloc_from(donor_if, alloc, alloc->hdr.donor_cookie);
 }
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_alloc_from(
+static int remote_numa_rx_mem_alloc_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_alloc_t *alloc,
 	u32 main_node_id)
@@ -1160,12 +1160,12 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_alloc_from(
 
     if (!mgr) {
         printk(KERN_DEBUG "No mem manager in donor.\n");
-        return remote_numa_receive_err_unknown;
+		return -EIO;
     }
 
     if (remote_numa_mem_alloc_page(mgr, &cookie, &page) != 0) {
         printk(KERN_DEBUG "Bad page alloc manager in donor.\n");
-        return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
     }
 
     void *tx_buf;
@@ -1176,7 +1176,7 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_alloc_from(
     if (!tx_buf || !ack) {
         printk(KERN_DEBUG "Bad tx alloc manager in donor.\n");
         remote_numa_mem_free_page(mgr, cookie); // Return page to pool
-        return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
     }
 
     ack->hdr.version = remote_numa_protocol_0_1;
@@ -1192,25 +1192,25 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_alloc_from(
 		REMOTE_NUMA_HASH_TABLE_ORDER,
 		main_node_id);
 	if (!main_node)
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 
     // Send the ack
     return donor_if->tx_msg(
                donor_if->trprt_ctx,
                main_node->priv_return_info,
                tx_buf) == 0
-           ? remote_numa_receive_success
-           : remote_numa_receive_err_unknown;
+	       ? 0
+	       : -EIO;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_free(
+int remote_numa_rx_mem_pg_free(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_free_t *pg_free)
 {
 	return remote_numa_rx_mem_pg_free_from(donor_if, pg_free, pg_free->hdr.donor_cookie);
 }
 
-static remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_from(
+static int remote_numa_rx_mem_pg_free_from(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_free_t *pg_free,
 	u32 main_node_id)
@@ -1236,7 +1236,7 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_from(
 
 	donor_if->alloc_tx_buffer(sizeof(*ack), &tx_buf, v);
 	if (!tx_buf || !ack)
-		return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
 
 	ack->hdr.version        = remote_numa_protocol_0_1;
 	ack->hdr.type           = remote_numa_mem_free_ack;
@@ -1249,17 +1249,17 @@ static remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_from(
 		REMOTE_NUMA_HASH_TABLE_ORDER,
 		main_node_id);
 	if (!main_node)
-		return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 
 	return donor_if->tx_msg(donor_if->trprt_ctx,
 	                        main_node->priv_return_info,
 	                        tx_buf) == 0
-	       ? remote_numa_receive_success
-	       : remote_numa_receive_err_unknown;
+	       ? 0
+	       : -EIO;
 }
 
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_ack(
+int remote_numa_rx_mem_pg_free_ack(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_free_ack_t *ack)
 {
@@ -1270,16 +1270,16 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_ack(
 	 */
 	main_xfer_state_t *xfer = xfer_get(ack->main_pg_cookie);
 	if (!xfer)
-		return remote_numa_receive_success;
+		return 0;
 
 	bitmap_fill(xfer->received_bitmap, PAGE_SIZE);
 	wake_up(&xfer->waitq);
 	xfer_put(xfer);
 
-	return remote_numa_receive_success;
+	return 0;
 }
 
-remote_numa_send_ret_t remote_numa_tx_mem_pg_free(
+int remote_numa_tx_mem_pg_free(
 	struct remote_numa_main_trprt_if *main_if,
 	u32 donor_id,
 	u64 donor_pg_cookie,
@@ -1295,7 +1295,7 @@ remote_numa_send_ret_t remote_numa_tx_mem_pg_free(
 	rcu_read_unlock();
 
 	if (!donor)
-		return remote_numa_send_no_if;
+		return -ENODEV;
 
 	/* Fire-and-forget FREE: no xfer_table entry, no wait on ACK. */
 	void *tx_buf;
@@ -1304,7 +1304,7 @@ remote_numa_send_ret_t remote_numa_tx_mem_pg_free(
 
 	main_if->alloc_tx_buffer(sizeof(*msg), &tx_buf, v);
 	if (!tx_buf || !msg)
-		return remote_numa_send_bad_alloc;
+		return -ENOMEM;
 
 	msg->hdr.version        = remote_numa_protocol_0_1;
 	msg->hdr.type           = remote_numa_mem_free;
@@ -1314,24 +1314,24 @@ remote_numa_send_ret_t remote_numa_tx_mem_pg_free(
 	msg->main_pg_cookie     = main_pg_cookie;
 
 	if (main_if->tx_msg(main_if->trprt_ctx, donor->priv_return_info, tx_buf))
-		return remote_numa_send_bad_xmit;
+		return -EIO;
 
-	return remote_numa_send_success;
+	return 0;
 }
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch_sat(
+int remote_numa_rx_mem_pg_refetch_sat(
     remote_numa_main_trprt_if_t *main_if,
     remote_numa_mem_pg_xfer_t *sat)
 {
 	main_xfer_state_t *xfer = xfer_get(sat->receiver_pg_cookie);
     if (!xfer)
     {
-	return remote_numa_receive_bad_cookie;
+	return -ENOENT;
     }
     if (sat->payload_len + sat->seq_num > PAGE_SIZE)
 	{
 		xfer_put(xfer);
-		return remote_numa_receive_out_of_bounds;
+		return -EOVERFLOW;
 	}
 
     /* write segment into local page */
@@ -1348,7 +1348,7 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch_sat(
     main_if->alloc_tx_buffer(sizeof(*ack), &ack_buf, v);
 	if (!ack_buf || !ack) {
 		xfer_put(xfer);
-		return remote_numa_receive_bad_alloc;
+		return -ENOMEM;
 	}
 
     ack->hdr.version        = REMOTE_NUMA_SUPPORTED_PROTO;
@@ -1369,7 +1369,7 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch_sat(
     if (!donor) {
         printk(KERN_ERR "refetch_sat: failed to find donor node %u\n", sat->hdr.main_cookie);
 		xfer_put(xfer);
-        return remote_numa_receive_bad_cookie;
+		return -ENOENT;
     }
 
     /* send ACK back to donor */
@@ -1386,23 +1386,23 @@ remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch_sat(
 	        xfer_put(xfer);
 	}
 
-    return remote_numa_receive_success;
+	return 0;
 }
 
-remote_numa_receive_ret_t
+int
 remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
                                   remote_numa_mem_pg_xfer_ack_t *ack)
 {
 	main_xfer_state_t *xfer = xfer_get(ack->receiver_pg_cookie);
     if (!xfer)
-        return remote_numa_receive_bad_cookie;
+		return -ENOENT;
 
     /* Stale in-flight? Keep behavior consistent with sync_ack: log and continue. */
     if (ack->hack != xfer->hack) {
         printk(KERN_INFO "Ignoring refetch_ack due to hack staleness (expected %d, got %d)\n",
                xfer->hack, ack->hack);
 		xfer_put(xfer);
-        return remote_numa_receive_success;  // Silently ignore stale acks
+		return 0;  // Silently ignore stale acks
     }
 
     /* Range-based ACK: handle out-of-order arrivals without over-marking. */
@@ -1418,7 +1418,7 @@ remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
 	        xfer_put(xfer);
 	}
 
-    return remote_numa_receive_success;
+	return 0;
 }
 
 void tmp_init(void)

--- a/drivers/staging/remote_numa/transport.h
+++ b/drivers/staging/remote_numa/transport.h
@@ -16,56 +16,11 @@
 #include "client_cache.h"
 #include "protocol.h"
 
-/* Create a return val for base + transport */
-#define REMOTE_NUMA_TRPRT_RET(code, trprt_code) ((u32)((trprt_code << 8) | (code & 0xFF)))
-
-/* Decode return val for send */
-#define REMOTE_NUMA_TRPRT_TX_RET_BASE(code) ((remote_numa_send_ret_t)(code & 0xFF))
-
-/* Decode return val for receive */
-#define REMOTE_NUMA_TRPRT_RX_RET_BASE(code) ((remote_numa_receive_ret_t)(code & 0xFF))
-
-/* Decode return val */
-#define REMOTE_NUMA_TRPT_RET_TRPRT_CODE(code) ((code & ~0xFF) >> 8)
-
 #define REMOTE_NUMA_HASH_TABLE_ORDER 16
 
 struct remote_numa_cached_page;
 struct remote_numa_client_cache;
 struct remote_numa_mem_mgr;
-
-/*
- * Return status for sending messages. Transports encode their specific
- * errors in the upper 3 bytes.
- */
-typedef enum
-{
-	remote_numa_send_success = 0,
-	remote_numa_send_err_unknown = 1,
-	remote_numa_send_bad_alloc = 2,
-	remote_numa_send_no_if = 3,
-	remote_numa_send_bad_xmit = 4,
-	remote_numa_send_timeout = 5,
-	/*After 255, they are transport-encoded.*/
-	remote_numa_send_max = 255,
-} remote_numa_send_ret_t;
-
-/*
- * Return status for receiving messages. Transports encode their specific
- * errors in the upper 3 bytes.
- */
-typedef enum
-{
-	remote_numa_receive_success = 0,
-	remote_numa_receive_err_unknown = 1,
-	remote_numa_receive_bad_alloc = 2,
-	remote_numa_receive_bad_proto = 3,
-	remote_numa_receive_mangled_pkt = 4,
-	remote_numa_receive_bad_cookie = 5,
-	remote_numa_receive_out_of_bounds = 6,
-	/*After 255, they are transport-encoded.*/
-	remote_numa_receive_max = 255,
-} remote_numa_receive_ret_t;
 
 typedef struct
 {
@@ -98,11 +53,11 @@ typedef struct remote_numa_donor_trprt_if
 	void (*alloc_tx_buffer)(size_t payload_len,
 		void **obj, void**payload_start);
 	void* (*priv_return_info_from_mem_query)(remote_numa_mem_query_t *);
-	remote_numa_send_ret_t (*tx_msg)(remote_numa_trprt_ctx_t *trprt_ctx,
+	int (*tx_msg)(remote_numa_trprt_ctx_t *trprt_ctx,
 		void *return_info, void *msg);
-	remote_numa_send_ret_t (*tx_advert)(remote_numa_trprt_ctx_t *trprt_ctx);
-	remote_numa_receive_ret_t (*rx_mem_query)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_query_t *query);
-	remote_numa_send_ret_t (*tx_mem_resp)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp);
+	int (*tx_advert)(remote_numa_trprt_ctx_t *trprt_ctx);
+	int (*rx_mem_query)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_query_t *query);
+	int (*tx_mem_resp)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp);
 
 	/* Some callbacks need transport-specific data. */
 	remote_numa_trprt_ctx_t *trprt_ctx;
@@ -112,7 +67,7 @@ typedef struct remote_numa_main_trprt_if
 {
 	u32 (*remote_numa_node_id)(remote_numa_advert_t *);
 	u16 (*get_max_payload_len)(void); // Does not count header.
-	remote_numa_send_ret_t (*priv_return_info)(
+	int (*priv_return_info)(
 		void *trprt_ctx, remote_numa_main_return_info_t *info);
 	void* (*priv_return_info_from_advert)(remote_numa_advert_t *);
 	void (*free_priv_return_info)(void*);
@@ -120,9 +75,9 @@ typedef struct remote_numa_main_trprt_if
 	void (*prepare_rx_buff)(void *rx_buff, void **payload);
 	void (*alloc_tx_buffer)(size_t payload_len,
 		void **obj, void**payload_start);
-	remote_numa_send_ret_t (*tx_msg)(remote_numa_trprt_ctx_t *trprt_ctx,
+	int (*tx_msg)(remote_numa_trprt_ctx_t *trprt_ctx,
 		void *return_info, void *msg);
-	remote_numa_receive_ret_t (*rx_mem_resp)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp);
+	int (*rx_mem_resp)(remote_numa_trprt_ctx_t *trprt_ctx, remote_numa_mem_resp_t *resp);
 
 	/* Some callbacks need transport-specific data. */
 	remote_numa_trprt_ctx_t *trprt_ctx;
@@ -133,41 +88,41 @@ remote_numa_trprt_ctx_t *remote_numa_make_trprt_ctx(struct remote_numa_mem_mgr *
 
 void remote_numa_transport_ctx_destroy(remote_numa_trprt_ctx_t *ctx);
 
-remote_numa_receive_ret_t remote_numa_main_rx(
+int remote_numa_main_rx(
 	remote_numa_main_trprt_if_t *main_if, void *rx_data, void *payload);
 
-remote_numa_receive_ret_t remote_numa_donor_rx(
+int remote_numa_donor_rx(
 	remote_numa_donor_trprt_if_t *donor_if, void *rx_data, void *payload);
 
-remote_numa_receive_ret_t remote_numa_rx_advert(
+int remote_numa_rx_advert(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_advert_t *advert);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_query(
+int remote_numa_rx_mem_query(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_query_t *query);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_resp(
+int remote_numa_rx_mem_resp(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_resp_t *resp);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_alloc(
+int remote_numa_rx_mem_alloc(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_alloc_t *alloc);
 
 /* Non-blocking variants - return immediately, use _check_transfer_complete to poll */
-remote_numa_send_ret_t remote_numa_transport_alloc_page_async(
+int remote_numa_transport_alloc_page_async(
 	remote_numa_main_trprt_if_t *trprt,
 	remote_numa_node_t *donor,
 	struct remote_numa_cached_page *cached_target);
 
-remote_numa_send_ret_t remote_numa_transport_refetch_page_async(
+int remote_numa_transport_refetch_page_async(
 	remote_numa_main_trprt_if_t *trprt,
 	u32 donor_node_id,
 	u64 donor_pg_cookie,
 	struct remote_numa_cached_page *cached_target);
 
-remote_numa_send_ret_t remote_numa_tx_mem_pg_sync_xfer_async(
+int remote_numa_tx_mem_pg_sync_xfer_async(
 	remote_numa_main_trprt_if_t *main_if,
 	u64 donor_pg_cookie,
 	struct page *pg,
@@ -179,37 +134,37 @@ int remote_numa_check_transfer_complete(struct remote_numa_cached_page *cached_p
 bool remote_numa_transport_is_transfer_complete(
 	struct remote_numa_cached_page *cached_target);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sat_ack(
+int remote_numa_rx_mem_pg_sat_ack(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_satisfaction_t *ack);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_xfer(
+int remote_numa_rx_mem_pg_sync_xfer(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_pg_xfer_t *xfer);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_sync_ack(
+int remote_numa_rx_mem_pg_sync_ack(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_pg_xfer_ack_t *xfer);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_free(
+int remote_numa_rx_mem_pg_free(
 	remote_numa_donor_trprt_if_t *donor_if,
 	remote_numa_mem_free_t *pg_free);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_free_ack(
+int remote_numa_rx_mem_pg_free_ack(
 	remote_numa_main_trprt_if_t *main_if,
 	remote_numa_mem_free_ack_t *ack);
 
-remote_numa_send_ret_t remote_numa_tx_mem_pg_free(
+int remote_numa_tx_mem_pg_free(
 	struct remote_numa_main_trprt_if *main_if,
 	u32 donor_id,
 	u64 donor_pg_cookie,
 	uintptr_t main_pg_cookie);
 
-remote_numa_receive_ret_t remote_numa_rx_mem_pg_refetch_sat(
+int remote_numa_rx_mem_pg_refetch_sat(
     remote_numa_main_trprt_if_t *main_if,
     remote_numa_mem_pg_xfer_t *sat);
 
-remote_numa_receive_ret_t
+int
 remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
                                   remote_numa_mem_pg_xfer_ack_t *ack);
 

--- a/drivers/staging/remote_numa/worker_pool.c
+++ b/drivers/staging/remote_numa/worker_pool.c
@@ -27,16 +27,14 @@ static int worker_count;
 static rx_func_t handler_fn;
 static bool rejecting_work;
 
-remote_numa_receive_ret_t remote_numa_submit_frame(void *frame)
+int remote_numa_submit_frame(void *frame)
 {
 	if (READ_ONCE(rejecting_work))
-		return REMOTE_NUMA_TRPRT_RET(
-			remote_numa_receive_err_unknown, 10);
+		return -ESHUTDOWN;
 
 	struct worker_job *job = kmalloc(sizeof(*job), GFP_ATOMIC);
 	if (!job)
-		return REMOTE_NUMA_TRPRT_RET(
-			remote_numa_receive_bad_alloc, 10);
+		return -ENOMEM;
 
 	job->frame = frame;
 	llist_add(&job->llnode, &job_list);

--- a/drivers/staging/remote_numa/worker_pool.h
+++ b/drivers/staging/remote_numa/worker_pool.h
@@ -10,11 +10,11 @@
 
 #include "transport.h"
 
-typedef remote_numa_receive_ret_t (*rx_func_t)(void *);
+typedef int (*rx_func_t)(void *);
 
 int remote_numa_worker_pool_init(rx_func_t handler, int num_workers);
 void remote_numa_worker_pool_stop(void);
-remote_numa_receive_ret_t remote_numa_submit_frame(void *frame);
+int remote_numa_submit_frame(void *frame);
 void remote_numa_worker_pool_set_reject(bool reject);
 
 #endif


### PR DESCRIPTION
Original error code thoughts were ok, but the standard interfaces are ... standard. Using the nonstandard types internally is ok, but wasn't buying anything.