### PR TITLE
Stylistic changes, lock cleanups, qwen stability, debug counters.

### DIFF
--- a/drivers/staging/remote_numa/Makefile
+++ b/drivers/staging/remote_numa/Makefile
@@ -6,7 +6,7 @@ obj-$(CONFIG_REMOTE_NUMA) += donor_node_module.o
 obj-$(CONFIG_REMOTE_NUMA) += remote_numa_test_module.o
 
 # Core module (shared implementation code)
-remote_numa_core-objs := transport.o memory.o client_cache.o worker_pool.o
+remote_numa_core-objs := transport.o memory.o client_cache.o worker_pool.o rn_counters.o
 
 # These modules just link against the core
 main_node_module-objs := main_node.o eth_transport.o

--- a/drivers/staging/remote_numa/client_cache.c
+++ b/drivers/staging/remote_numa/client_cache.c
@@ -14,6 +14,7 @@
 #include "client_cache.h"
 
 #include "transport.h"
+#include "rn_counters.h"
 
 #define REMOTE_NUMA_REFAULT_HASH_BITS 12
 
@@ -43,7 +44,7 @@ static void remote_numa_pg_free_workfn(struct work_struct *work)
 	 */
 	int ret = remote_numa_tx_mem_pg_free(w->trprt, w->donor_id, w->donor_pg_cookie, w->main_pg_cookie);
 	if (ret) {
-		 printk(KERN_WARNING "remote_numa: Error freeing remote page: ret=%d, donor_id=%u, donor_pg_cookie=%llu, main_pg_cookie=0x%lx\n",
+		 printk_ratelimited(KERN_WARNING "remote_numa: Error freeing remote page: ret=%d, donor_id=%u, donor_pg_cookie=%llu, main_pg_cookie=0x%lx\n",
 			 ret, w->donor_id, w->donor_pg_cookie, (unsigned long)w->main_pg_cookie);
 	}
 	kfree(w);
@@ -57,8 +58,16 @@ static void remote_numa_tx_mem_pg_free_async(remote_numa_main_trprt_if_t *trprt,
 	struct remote_numa_pg_free_work *w =
 		kmalloc(sizeof(*w), GFP_ATOMIC);
 	if (!w) {
-		/* fallback: leak or warn */
-		WARN_ON_ONCE(1);
+		/*
+		 * OOM: this is an expected condition under memory pressure, not a
+		 * bug, so do not WARN_ON_ONCE (which dumps a stack). Leak this
+		 * remote free - the donor holds the page - which is acceptable
+		 * per the model above. Rate-limit so an allocation-failure burst
+		 * cannot flood the log.
+		 */
+		printk_ratelimited(KERN_WARNING
+			"remote_numa: OOM in tx_mem_pg_free_async; leaking remote free (donor_id=%u, donor_pg_cookie=%llu, main_pg_cookie=0x%lx)\n",
+			donor_id, donor_pg_cookie, (unsigned long)main_pg_cookie);
 		return;
 	}
 	INIT_WORK(&w->work, remote_numa_pg_free_workfn);
@@ -74,44 +83,93 @@ static inline u64 known_page_hash(struct page *page) {
 	return hash_long((unsigned long)page, REMOTE_NUMA_CLIENT_CACHE_HASH_BITS);
 }
 
+/* Hash key for addr_lookup: maps a (mm, addr) pair to its cached page slot. */
+static inline u32 addr_key(struct mm_struct *mm, unsigned long addr)
+{
+	return hash_long(((unsigned long)mm >> 4) ^ addr, REMOTE_NUMA_CLIENT_CACHE_HASH_BITS);
+}
+
+/*
+ * known_pages is a per-cache hash shared by the alloc/free/refault paths.
+ * Every traversal and mutation below holds cache->lock so concurrent
+ * hash_add/hash_del/hash_for_each on the same bucket cannot corrupt the
+ * hlist. Callers must not invoke these while already holding cache->lock.
+ */
 static inline void known_pages_insert(remote_numa_client_cache_t *cache, remote_numa_known_page_t *kp, struct page *page, struct mm_struct *mm, unsigned long addr) {
 	kp->page = page;
 	kp->mm = mm;
 	kp->addr = addr;
+	spin_lock(&cache->lock);
 	hash_add(cache->known_pages, &kp->node, known_page_hash(page));
+	spin_unlock(&cache->lock);
 }
 
 static inline remote_numa_known_page_t *known_pages_lookup(remote_numa_client_cache_t *cache, struct page *page) {
 	remote_numa_known_page_t *kp;
 	u64 key = known_page_hash(page);
+	spin_lock(&cache->lock);
 	hash_for_each_possible(cache->known_pages, kp, node, key) {
-		  if (kp->page == page)
+		  if (kp->page == page) {
+			    spin_unlock(&cache->lock);
 			    return kp;
+		  }
 	}
+	spin_unlock(&cache->lock);
 	return NULL;
 }
 
 static inline void known_pages_remove(remote_numa_client_cache_t *cache, struct page *page) {
-	remote_numa_known_page_t *kp = known_pages_lookup(cache, page);
-	if (kp)
-		  hash_del(&kp->node);
+	remote_numa_known_page_t *kp;
+	u64 key = known_page_hash(page);
+	spin_lock(&cache->lock);
+	hash_for_each_possible(cache->known_pages, kp, node, key) {
+		if (kp->page == page) {
+			hash_del(&kp->node);
+			spin_unlock(&cache->lock);
+			return;
+		}
+	}
+	spin_unlock(&cache->lock);
 }
 
 /* assumes lock is held */
 static remote_numa_node_t *choose_donor(remote_numa_client_cache_t *cache)
 {
 	remote_numa_node_t *node;
+	remote_numa_node_t *first_valid = NULL;
 	int bkt;
 
 	rcu_read_lock();
 	hash_for_each(cache->trprt->trprt_ctx->node_table, bkt, node, hnode) {
-		if (node->valid_mem_resp && node->free_pages > 0) {
+		if (!node->valid_mem_resp)
+			continue;
+		if (!first_valid)
+			first_valid = node;
+		/*
+		 * free_pages is a read-modify-write here and is also written by
+		 * remote_numa_rx_mem_resp(). Serialize both under node_lock so the
+		 * estimate cannot be corrupted by a concurrent decrement or store.
+		 */
+		spin_lock(&node->node_lock);
+		if (node->free_pages > 0) {
 			node->free_pages--;
-			break;
+			spin_unlock(&node->node_lock);
+			rcu_read_unlock();
+			return node;
 		}
+		spin_unlock(&node->node_lock);
 	}
 	rcu_read_unlock();
-	return node;
+	/*
+	 * Local free_pages estimate is exhausted or stale. Fall back to the
+	 * first valid donor and let it reject the request if it is truly out
+	 * of pages. This avoids getting stuck when the local count has gone
+	 * to zero due to concurrent decrements or lack of a fresh mem_resp.
+	 */
+	if (!first_valid)
+		printk_ratelimited(KERN_WARNING "choose_donor: no valid donor (no valid_mem_resp) node_table=%s\n",
+		       "empty-or-no-valid");
+	return first_valid;
 }
 
 
@@ -139,8 +197,13 @@ static void defer_mmdrop(struct mm_struct *mm)
 
     w = kmalloc(sizeof(*w), GFP_ATOMIC);
     if (!w) {
-        /* last-ditch fallback: leak or WARN */
-        WARN_ON_ONCE(1);
+        /*
+         * OOM: expected under memory pressure, not a bug. Do not WARN_ON_ONCE.
+         * Leak this mm reference rather than treat it as a logic error.
+         * Rate-limit so a burst of failures cannot flood the log.
+         */
+        printk_ratelimited(KERN_WARNING
+            "remote_numa: OOM in defer_mmdrop; leaking mm ref\n");
         return;
     }
 
@@ -242,23 +305,44 @@ static int maybe_evict(remote_numa_client_cache_t *cache)
 	}
 
 	if (list_empty(&cache->lru_head)) {
+		/*
+		 * Cache is full but nothing is in the LRU list. That means every
+		 * in-use entry is either being evicted (evicting_list) or is
+		 * transiently in progress. The background worker will complete
+		 * those evictions and free entries back to free_list, so this is
+		 * a transient condition: ask the caller to retry rather than
+		 * failing the allocation.
+		 */
 		spin_unlock(&cache->lock);
-		return -ENOMEM;
+		return -EAGAIN;
 	}
 
-	/* Find a victim that's not currently being transferred */
-	list_for_each_entry(victim, &cache->lru_head, lru_list) {
-		if (atomic_read(&victim->transfer_in_progress) == 0) {
-			/* Try to claim it for eviction */
-			if (atomic_cmpxchg(&victim->transfer_in_progress, 0, 1) == 0) {
-				if (victim->known_page)
-					atomic_set(&victim->known_page->evict_in_progress, 1);
-				/* Successfully claimed - remove from LRU */
-				list_del(&victim->lru_list);
-				hash_del(&victim->node);
-				/* Don't decrement current_cached_pages yet - page isn't free */
-				spin_unlock(&cache->lock);
-				goto evict_victim;
+	/*
+	 * Evict the OLDEST (least-recently-used) entry, i.e. the tail of the
+	 * list. cache_insert() adds freshly allocated and re-faulted entries at
+	 * the head (MRU), so the head is the newest page and the tail is the
+	 * oldest. Walking from the head would evict the most recently touched
+	 * page (LIFO), which lets a just-allocated page be synced to the donor
+	 * before its initial data has been written -- the donor then stores
+	 * zeros and every later refetch returns corrupt (zero) data.
+	 */
+	{
+		struct remote_numa_cached_page *pos, *n;
+		list_for_each_entry_safe_reverse(pos, n, &cache->lru_head, lru_list) {
+			if (atomic_read(&pos->transfer_in_progress) == 0) {
+				/* Try to claim it for eviction */
+				if (atomic_cmpxchg(&pos->transfer_in_progress, 0, 1) == 0) {
+					victim = pos;
+					if (victim->known_page)
+						atomic_set(&victim->known_page->evict_in_progress, 1);
+					/* Successfully claimed - remove from LRU */
+					list_del(&victim->lru_list);
+					hash_del(&victim->node);
+					hash_del(&victim->addr_node);
+					/* Don't decrement current_cached_pages yet - page isn't free */
+					spin_unlock(&cache->lock);
+					goto evict_victim;
+				}
 			}
 		}
 	}
@@ -287,6 +371,8 @@ evict_victim:
 		list_add(&victim->lru_list, &cache->lru_head);
 		/* No need to increment current_cached_pages - we never decremented it */
 		hash_add(cache->page_lookup, &victim->node, (uintptr_t)victim->known_page->page);
+		hash_add(cache->addr_lookup, &victim->addr_node,
+			 addr_key(victim->known_page->mm, victim->known_page->addr));
 		spin_unlock(&cache->lock);
 		return ret;
 	}
@@ -338,6 +424,8 @@ static void cache_insert(remote_numa_client_cache_t *cache,
 	spin_lock(&cache->lock);
 	list_add(&entry->lru_list, &cache->lru_head);
 	hash_add(cache->page_lookup, &entry->node, (uintptr_t)entry->known_page->page);
+	hash_add(cache->addr_lookup, &entry->addr_node,
+		 addr_key(entry->known_page->mm, entry->known_page->addr));
 	spin_unlock(&cache->lock);
 }
 
@@ -444,6 +532,7 @@ int remote_numa_client_cache_init(remote_numa_client_cache_t *cache,
 
 	hash_init(cache->page_lookup);
 	hash_init(cache->known_pages);
+	hash_init(cache->addr_lookup);
 	hash_init(refault_table);
 
 	for (u32 i = 0; i < max_cached_pages; ++i) {
@@ -462,54 +551,104 @@ void remote_numa_client_cache_destroy(remote_numa_client_cache_t *cache)
 {
 	struct list_head *pos, *tmp;
 	remote_numa_cached_page_t *entry;
+	int bkt;
+	remote_numa_known_page_t *kp;
+	struct hlist_node *tmp2;
 
-	/* Cancel background worker */
+	/* Cancel background worker first: no concurrent list/hash mutation. */
 	cancel_delayed_work_sync(&cache->eviction_completion_work);
 
+	/*
+	 * Active entries (lru_head): live known_page, present in
+	 * page_lookup/addr_lookup and known_pages, holding an mm ref.
+	 */
 	list_for_each_safe(pos, tmp, &cache->lru_head) {
 		entry = list_entry(pos, remote_numa_cached_page_t, lru_list);
 		list_del(pos);
 		hash_del(&entry->node);
-		__free_page(entry->known_page->page);
-		kfree(entry->known_page);
-		       if (entry->known_page && entry->known_page->mm) {
-			       mmdrop(entry->known_page->mm);
-		       }
+		hash_del(&entry->addr_node);
+		if (entry->known_page) {
+			kp = entry->known_page;
+			hash_del(&kp->node);
+			if (kp->mm)
+				mmdrop(kp->mm);
+			__free_page(kp->page);
+			kfree(kp);
+			entry->known_page = NULL;
+		}
 		kfree(entry);
 	}
+
+	/*
+	 * Entries mid-eviction (evicting_list): detached from page_lookup /
+	 * addr_lookup at claim time, but the known_page (and its mm ref) is
+	 * still live and still in known_pages.
+	 */
+	list_for_each_safe(pos, tmp, &cache->evicting_list) {
+		entry = list_entry(pos, remote_numa_cached_page_t, lru_list);
+		list_del(pos);
+		if (entry->known_page) {
+			kp = entry->known_page;
+			hash_del(&kp->node);
+			if (kp->mm)
+				mmdrop(kp->mm);
+			__free_page(kp->page);
+			kfree(kp);
+			entry->known_page = NULL;
+		}
+		kfree(entry);
+	}
+
+	/*
+	 * Recycled slots (free_list): normally known_page is NULL and the slot
+	 * is in no hash. A refetch that failed after taking a known_page leaves
+	 * a live one here, so guard and release it too.
+	 */
 	list_for_each_safe(pos, tmp, &cache->free_list) {
 		entry = list_entry(pos, remote_numa_cached_page_t, lru_list);
 		list_del(pos);
-		__free_page(entry->known_page->page);
-		kfree(entry->known_page);
-		       if (entry->known_page && entry->known_page->mm) {
-			       mmdrop(entry->known_page->mm);
-		       }
+		if (entry->known_page) {
+			kp = entry->known_page;
+			hash_del(&kp->node);
+			if (kp->mm)
+				mmdrop(kp->mm);
+			__free_page(kp->page);
+			kfree(kp);
+			entry->known_page = NULL;
+		}
 		kfree(entry);
 	}
-	       cache->current_cached_pages = 0;
 
-	       /* Clear known_pages hash table */
-		       int bkt;
-		       remote_numa_known_page_t *kp;
-		       struct hlist_node *tmp2;
-		       hash_for_each_safe(cache->known_pages, bkt, tmp2, kp, node) {
-			       hash_del(&kp->node);
-			       kfree(kp);
-		       }
+	/*
+	 * Release any known_page still left in the hash (e.g. detached from its
+	 * slot by an in-flight eviction). Per-slot kps above were hash_del'ed,
+	 * so this only sees the ones no slot references anymore.
+	 */
+	hash_for_each_safe(cache->known_pages, bkt, tmp2, kp, node) {
+		hash_del(&kp->node);
+		if (kp->mm)
+			mmdrop(kp->mm);
+		__free_page(kp->page);
+		kfree(kp);
+	}
 
-	       refault_table_clear();
+	cache->current_cached_pages = 0;
+	refault_table_clear();
 }
 
 struct page *remote_numa_client_cache_alloc(remote_numa_client_cache_t *cache,
 	struct vm_fault *vmf)
 {
 	remote_numa_cached_page_t *existing;
-	int bkt;
-	
-	/* Check if there's already an ongoing allocation for this address */
+	const char *fail_reason = "unknown";
+
+	/* Check if there's already an ongoing allocation for this address.
+	 * O(1) via addr_lookup ((mm, addr) keyed) instead of a full table walk.
+	 */
+	u32 key = addr_key(vmf->vma->vm_mm, vmf->address);
+
 	spin_lock(&cache->lock);
-	       hash_for_each(cache->page_lookup, bkt, existing, node) {
+	hash_for_each_possible(cache->addr_lookup, existing, addr_node, key) {
 		       remote_numa_known_page_t *kp = existing->known_page;
 		       if (kp && kp->mm == vmf->vma->vm_mm && kp->addr == vmf->address) {
 			       /* Fast path: already complete */
@@ -542,83 +681,77 @@ struct page *remote_numa_client_cache_alloc(remote_numa_client_cache_t *cache,
 		/* Eviction in progress; caller should retry. */
 		return ERR_PTR(-EAGAIN);
 	} else if (evict_ret) {
+		fail_reason = "maybe_evict_first";
 		goto err;
 	}
 
 	remote_numa_cached_page_t *entry = reuse_page(cache);
-	if (!entry) {
-		/*
-		 * Under contention, another thread may have consumed the last free entry
-		 * after our eviction check. Try to kick eviction once more and ask the
-		 * caller to retry rather than failing the allocation.
-		 */
-		evict_ret = maybe_evict(cache);
-		if (evict_ret == -EAGAIN || evict_ret == 0)
-			return ERR_PTR(-EAGAIN);
-		if (evict_ret)
-			goto err;
+ 	if (!entry) {
+ 		/*
+ 		 * Under contention, another thread may have consumed the last free entry
+ 		 * after our eviction check. Try to kick eviction once more and ask the
+ 		 * caller to retry rather than failing the allocation.
+ 		 */
+ 		evict_ret = maybe_evict(cache);
+ 		if (evict_ret == -EAGAIN || evict_ret == 0)
+ 			return ERR_PTR(-EAGAIN);
+ 		if (evict_ret) {
+ 			fail_reason = "maybe_evict_second";
+ 			goto err;
+ 		}
 
-		       unsigned int free_len = 0, lru_len = 0, lru_busy = 0, evict_len = 0;
-		       remote_numa_cached_page_t *it;
-		       u32 cur_cached, max_cached;
-		       spin_lock(&cache->lock);
-		       cur_cached = cache->current_cached_pages;
-		       max_cached = cache->max_cached_pages;
-		       list_for_each_entry(it, &cache->free_list, lru_list)
-			       free_len++;
-		       list_for_each_entry(it, &cache->lru_head, lru_list) {
-			       lru_len++;
-			       if (atomic_read(&it->transfer_in_progress))
-				       lru_busy++;
-		       }
-		       list_for_each_entry(it, &cache->evicting_list, lru_list)
-			       evict_len++;
-		       spin_unlock(&cache->lock);
-		       printk_ratelimited(KERN_DEBUG "reuse_page() fail: cur_cached=%u max=%u free=%u lru=%u lru_busy=%u evicting=%u\n",
-			       cur_cached, max_cached, free_len, lru_len, lru_busy, evict_len);
-		       return ERR_PTR(-EAGAIN);
-	       }
+ 		entry = reuse_page(cache);
+ 		if (!entry) {
+ 			fail_reason = "reuse_page_2";
+ 			goto err;
+ 		}
+ 	}
 
-	       /* Always allocate a new known_page for this (mm, addr) */
-		       struct page *page = alloc_page(GFP_KERNEL);
-		       if (!page) {
-			       spin_lock(&cache->lock);
-			       list_add(&entry->lru_list, &cache->free_list);
-			       cache->current_cached_pages--;
-			       spin_unlock(&cache->lock);
-			       return ERR_PTR(-ENOMEM);
-		       }
-		       struct remote_numa_known_page *kp = kzalloc(sizeof(*kp), GFP_KERNEL);
-		       if (!kp) {
-			       __free_page(page);
-			       spin_lock(&cache->lock);
-			       list_add(&entry->lru_list, &cache->free_list);
-			       cache->current_cached_pages--;
-			       spin_unlock(&cache->lock);
-			       goto err;
-		       }
-		       kp->donor_pg_cookie = 0;
-		       kp->donor_id = 0;
-		       kp->donor_cookie = 0;
-		       kp->main_pg_cookie = 0;
-		       known_pages_insert(cache, kp, page, vmf->vma->vm_mm, vmf->address);
-		       entry->known_page = kp;
+ 	/* Always allocate a new known_page for this (mm, addr) */
+ 	struct page *page = alloc_page(GFP_ATOMIC);
+ 	if (!page) {
+ 		spin_lock(&cache->lock);
+ 		list_add(&entry->lru_list, &cache->free_list);
+ 		cache->current_cached_pages--;
+ 		spin_unlock(&cache->lock);
+ 		return ERR_PTR(-ENOMEM);
+ 	}
+ 	struct remote_numa_known_page *kp = kzalloc(sizeof(*kp), GFP_ATOMIC);
+ 	if (!kp) {
+ 		__free_page(page);
+ 		spin_lock(&cache->lock);
+ 		list_add(&entry->lru_list, &cache->free_list);
+ 		cache->current_cached_pages--;
+ 		spin_unlock(&cache->lock);
+ 		fail_reason = "kzalloc_kp";
+ 		goto err;
+ 	}
+ 	kp->donor_pg_cookie = 0;
+ 	kp->donor_id = 0;
+ 	kp->donor_cookie = 0;
+ 	kp->main_pg_cookie = 0;
+ 	known_pages_insert(cache, kp, page, vmf->vma->vm_mm, vmf->address);
+ 	entry->known_page = kp;
 
-	       /* Initialize transfer flag - this entry is now being allocated */
-	       atomic_set(&entry->transfer_in_progress, 1);
+ 	/* Initialize transfer flag - this entry is now being allocated */
+ 	atomic_set(&entry->transfer_in_progress, 1);
 
-	       bool need_rcu_unlock = !rcu_read_lock_held();
-	       bool took_rcu_lock = false;
-	       if (need_rcu_unlock) {
-		       rcu_read_lock();
-		       took_rcu_lock = true;
-	       }
+ 	bool need_rcu_unlock = !rcu_read_lock_held();
+ 	bool took_rcu_lock = false;
+ 	if (need_rcu_unlock) {
+ 		rcu_read_lock();
+ 		took_rcu_lock = true;
+ 	}
 
-	       remote_numa_node_t *donor = choose_donor(cache);
+ 	remote_numa_node_t *donor = choose_donor(cache);
+ 	if (!donor) {
+ 		fail_reason = "choose_donor_null";
+ 		goto err;
+ 	}
 
-	       entry->known_page->donor_pg_cookie = 0;
-	       entry->known_page->donor_id = donor->node_id;
-	       entry->known_page->donor_cookie = donor->donor_cookie;
+ 	entry->known_page->donor_pg_cookie = 0;
+ 	entry->known_page->donor_id = donor->node_id;
+ 	entry->known_page->donor_cookie = donor->donor_cookie;
 		mmgrab(kp->mm);
 
 		       if (need_rcu_unlock && took_rcu_lock) {
@@ -628,7 +761,7 @@ struct page *remote_numa_client_cache_alloc(remote_numa_client_cache_t *cache,
 		       if (remote_numa_transport_alloc_page_async(cache->trprt,
 						    donor,
 						    entry)) {
-			       printk(KERN_DEBUG "Call to remote_numa_transport_alloc_page_async failed.\n");
+			       pr_debug("remote_numa: transport_alloc_page_async failed\n");
 			       atomic_set(&entry->transfer_in_progress, 0);
 			       spin_lock(&cache->lock);
 			       list_add(&entry->lru_list, &cache->free_list);
@@ -636,17 +769,17 @@ struct page *remote_numa_client_cache_alloc(remote_numa_client_cache_t *cache,
 			       spin_unlock(&cache->lock);
 			       known_pages_remove(cache, kp->page);
 			       kfree(kp);
+			       entry->known_page = NULL;
+			       fail_reason = "async_alloc";
 			       goto err;
-		       }
+ 		       }
 
 	       cache_insert(cache, entry);
 	       return ERR_PTR(-EAGAIN);
 err:
-	printk(KERN_DEBUG "Failure to allocate remote page.\n");
+	pr_debug("remote_numa: alloc failed reason=%s\n", fail_reason);
 	return ERR_PTR(-ENOMEM);
 }
-
-int here = 0;
 
 int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 				     struct page *faulting_page,
@@ -655,23 +788,31 @@ int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 	struct mm_struct *mm = vmf->vma->vm_mm;
 	unsigned long addr = vmf->address;
 	remote_numa_cached_page_t *existing;
-	int bkt;
+	atomic_inc(&rn_rf_enter);
 
-	/* Check if there's already an ongoing refault for this address */
+	/* Check if there's already an ongoing refault for this address.
+	 * O(1) via addr_lookup ((mm, addr) keyed) instead of a full table walk.
+	 */
+	u32 key = addr_key(mm, addr);
+
 	spin_lock(&cache->lock);
-	hash_for_each(cache->page_lookup, bkt, existing, node) {
+	hash_for_each_possible(cache->addr_lookup, existing, addr_node, key) {
 			   if (existing->known_page && existing->known_page->mm == mm && existing->known_page->addr == addr) {
 			/* Found existing entry - check if transfer is complete */
+			atomic_inc(&rn_rf_existing);
 			spin_unlock(&cache->lock);
 			/* Check if transfer is complete */
 			if (remote_numa_transport_is_transfer_complete(existing)) {
 				atomic_set(&existing->transfer_in_progress, 0);
+				atomic_inc(&rn_rf_existing_done);
 				return 0; /* Transfer complete */
 			} else if (atomic_read(&existing->transfer_in_progress)) {
 				/* Still in progress */
+				atomic_inc(&rn_rf_existing_wip);
 				return -EAGAIN;
 			}
 			/* Error case - fall through to retry */
+			atomic_inc(&rn_rf_existing_err);
 			break;
 		}
 	}
@@ -680,22 +821,29 @@ int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 	int evict_ret = maybe_evict(cache);
 	if (evict_ret == -EAGAIN) {
 		/* Eviction blocked by in-progress transfer, tell caller to retry */
+		atomic_inc(&rn_rf_evict_eagain);
 		return -EAGAIN;
 	} else if (evict_ret) {
+		atomic_inc(&rn_rf_evict_enomem);
 		return -ENOMEM;
 	}
 
 	u64 donor_pg_cookie;
 	u32 donor_id;
-	if (!refault_table_consume(mm, addr, &donor_pg_cookie, &donor_id))
+	if (!refault_table_consume(mm, addr, &donor_pg_cookie, &donor_id)) {
+		atomic_inc(&rn_rf_noent);
 		return -ENOENT;
+	}
 
 	remote_numa_cached_page_t *entry = reuse_page(cache);
 	if (!entry) {
 		/* Cache full under contention; try to evict and retry. */
 		evict_ret = maybe_evict(cache);
-		if (evict_ret == -EAGAIN || evict_ret == 0)
+		if (evict_ret == -EAGAIN || evict_ret == 0) {
+			atomic_inc(&rn_rf_reuse_eagain);
 			return -EAGAIN;
+		}
+		atomic_inc(&rn_rf_reuse_enomem);
 		return -ENOMEM;
 	}
 
@@ -706,6 +854,7 @@ int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 				* Should never happen, but under concurrency we must not leak
 				* entries from free_list.
 				*/
+			       atomic_inc(&rn_rf_kp_null);
 			       atomic_set(&entry->transfer_in_progress, 0);
 			       spin_lock(&cache->lock);
 			       list_add(&entry->lru_list, &cache->free_list);
@@ -724,9 +873,10 @@ int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 
 	       /* Initiate async refetch - returns immediately */
 	       if (remote_numa_transport_refetch_page_async(cache->trprt,
-					       donor_id,
-					       donor_pg_cookie,
-					       entry)) {
+				       donor_id,
+				       donor_pg_cookie,
+				       entry)) {
+		       atomic_inc(&rn_rf_refetch_eio);
 		       atomic_set(&entry->transfer_in_progress, 0);
 		       spin_lock(&cache->lock);
 		       list_add(&entry->lru_list, &cache->free_list);
@@ -739,6 +889,7 @@ int remote_numa_client_cache_refault(remote_numa_client_cache_t *cache,
 	       cache_insert(cache, entry);
 
 	       /* Return EAGAIN - caller must retry and check for completion */
+	       atomic_inc(&rn_rf_refetch_start);
 	       return -EAGAIN;
 }
 
@@ -756,7 +907,7 @@ int remote_numa_client_cache_free_page(remote_numa_client_cache_t *cache,
 	/* Remove from known_pages and free known_page and its page. Drive found/not found by this. */
 	remote_numa_known_page_t *kp = known_pages_lookup(cache, page);
 	if (!kp) {
-		printk(KERN_WARNING "remote_numa: No entry found for free.\n");
+		printk_ratelimited(KERN_WARNING "remote_numa: No entry found for free.\n");
 		return -ENOENT;
 	}
 	donor_id = kp->donor_id;
@@ -787,6 +938,7 @@ int remote_numa_client_cache_free_page(remote_numa_client_cache_t *cache,
 			list_del(&entry->lru_list);
 			cache->current_cached_pages--;
 			hash_del(&entry->node);
+			hash_del(&entry->addr_node);
 			/* Now it is safe to drop known_pages membership. */
 			hash_del(&kp->node);
 			/* Detach before freeing kp to avoid dangling pointer on reuse. */

--- a/drivers/staging/remote_numa/client_cache.h
+++ b/drivers/staging/remote_numa/client_cache.h
@@ -37,7 +37,9 @@ typedef struct remote_numa_cached_page {
 	struct remote_numa_known_page *known_page;
 	struct list_head lru_list;
 	uintptr_t main_pg_cookie;
+	u64 xfer_cookie;
 	struct hlist_node node;
+	struct hlist_node addr_node; /* for addr_lookup ((mm, addr) -> slot) */
 	atomic_t transfer_in_progress; /* non-zero if alloc/refault/evict in flight */
 } remote_numa_cached_page_t;
 
@@ -52,6 +54,7 @@ typedef struct remote_numa_client_cache {
 	struct remote_numa_main_trprt_if *trprt;
 	DECLARE_HASHTABLE(page_lookup, REMOTE_NUMA_CLIENT_CACHE_HASH_BITS);
 	DECLARE_HASHTABLE(known_pages, REMOTE_NUMA_CLIENT_CACHE_HASH_BITS);
+	DECLARE_HASHTABLE(addr_lookup, REMOTE_NUMA_CLIENT_CACHE_HASH_BITS);
 	struct delayed_work eviction_completion_work;
 } remote_numa_client_cache_t;
 

--- a/drivers/staging/remote_numa/main_node.c
+++ b/drivers/staging/remote_numa/main_node.c
@@ -21,8 +21,14 @@
 #include "worker_pool.h"
 
 #define WORKER_POOL_SIZE 4
-//#define REMOTE_NUMA_MAX_CACHED_PGS 128000
-#define REMOTE_NUMA_MAX_CACHED_PGS 1200
+
+/*
+ * Client cache capacity (pages), settable at insmod time. The stress test's
+ * total working set must exceed this to exercise eviction/refault.
+ */
+static int max_cached_pages = 1500;
+module_param(max_cached_pages, int, 0644);
+MODULE_PARM_DESC(max_cached_pages, "client cache capacity in pages");
 
 remote_numa_main_trprt_if_t *ctx = NULL;
 remote_numa_client_cache_t *client_cache = NULL;
@@ -57,7 +63,7 @@ remote_numa_main_node_init(void)
 	if ((cache_init = remote_numa_client_cache_init(
 		client_cache,
 		ctx,
-		REMOTE_NUMA_MAX_CACHED_PGS)))
+		max_cached_pages)))
 	{
 		printk(KERN_ERR "Could not init client cache.");
 		return cache_init;

--- a/drivers/staging/remote_numa/memory.c
+++ b/drivers/staging/remote_numa/memory.c
@@ -185,19 +185,21 @@ int remote_numa_mem_lookup_page(struct remote_numa_mem_mgr *mgr,
 	u32 h = cookie_hash(cookie);
 	struct hlist_head *head = &mgr->cookie_table[h];
 	remote_numa_page_t *pg;
-	
-	unsigned long flags;
-	spin_lock_irqsave(&mgr->lock, flags);
 
+	/*
+	 * cookie_table is built once at init and its hnode links are never
+	 * modified afterwards (pages are only moved on the free_list, which is
+	 * a separate structure guarded by mgr->lock). The fields read here
+	 * (donor_pg_cookie, addr) are set at init and immutable, so this
+	 * pure lookup needs no lock.
+	 */
 	hlist_for_each_entry(pg, head, hnode) {
 		if (pg->donor_pg_cookie == cookie) {
-		spin_unlock_irqrestore(&mgr->lock, flags);
 			*page_out = pg->addr;
 			*rn_pg_out = pg;
 			return 0;
 		}
 	}
-	spin_unlock_irqrestore(&mgr->lock, flags);
 	return -ENOENT;
 }
 

--- a/drivers/staging/remote_numa/remote_numa_test.c
+++ b/drivers/staging/remote_numa/remote_numa_test.c
@@ -32,30 +32,51 @@
 
 #include "client_cache.h"
 #include "transport.h"
+#include "rn_counters.h"
 
 #include <linux/kthread.h>
 #include <linux/random.h>
 
 #define REMOTE_NUMA_STRESS_TEST 1
-#define REMOTE_NUMA_STRESS_MAX_CONCURRENT_OPS 4
-#define REMOTE_NUMA_STRESS_MINUTES 5
-#define REMOTE_NUMA_STRESS_THREADS 5
-
-/* Burst size for churn/refault/free operations in the main stress loop. */
-#define REMOTE_NUMA_STRESS_BURST_OPS 128
 
 /*
- * Number of distinct (addr,page) slots the stress test touches.
- * Must be > cache capacity (1200) to reliably trigger evictions/refaults.
+ * Stress test configuration (settable at insmod time).
+ *
+ * The userspace test mmaps a large region and issues one RUN_TEST ioctl;
+ * the kernel then spawns stress_threads kthreads that churn alloc/refault/
+ * free for stress_minutes. stress_test_pages must exceed the client cache
+ * capacity to reliably trigger evictions/refaults.
  */
-#define REMOTE_NUMA_STRESS_TEST_PAGES (1200 + 600)
+static int stress_minutes = 2;
+module_param(stress_minutes, int, 0644);
+MODULE_PARM_DESC(stress_minutes, "stress test duration (minutes)");
+
+static int stress_threads = 9;
+module_param(stress_threads, int, 0644);
+MODULE_PARM_DESC(stress_threads, "number of stress kthreads");
+
+static int stress_test_pages = 1800;
+module_param(stress_test_pages, int, 0644);
+MODULE_PARM_DESC(stress_test_pages, "distinct pages touched (must exceed cache capacity)");
+
+static int stress_burst_ops = 128;
+module_param(stress_burst_ops, int, 0644);
+MODULE_PARM_DESC(stress_burst_ops, "ops per churn/refault/free burst");
+
+static int stress_cache_size = 1500;
+module_param(stress_cache_size, int, 0644);
+MODULE_PARM_DESC(stress_cache_size, "logical hot working-set size (victim pages)");
+
+static int stress_max_concurrent = 9;
+module_param(stress_max_concurrent, int, 0644);
+MODULE_PARM_DESC(stress_max_concurrent, "max concurrent alloc/refault/free ops");
 
 struct stress_test_ctx {
     struct semaphore sem;
     atomic_long_t active_allocs;
+    atomic_t initial_done;
+    atomic_t total_threads;
 };
-
-#define REMOTE_NUMA_STRESS_CACHE_SIZE 1200
 
 struct stress_thread_info {
     int id;
@@ -152,7 +173,7 @@ static int stress_alloc_idx(struct stress_thread_info *info, int idx, unsigned l
 
     prep_ret = stress_prepare_vmf(info->mm, cur_addr, &fake_vmf);
     if (prep_ret) {
-         printk(KERN_DEBUG "[STRESS %d] ALLOC VMA not found for idx=%d addr=%px active_total=%ld active_thread=%lu\n",
+          pr_debug("[STRESS %d] ALLOC VMA not found for idx=%d addr=%px active_total=%ld active_thread=%lu\n",
              info->id, idx, (void *)cur_addr,
              atomic_long_read(&info->ctx->active_allocs),
              info->active_owned);
@@ -162,7 +183,7 @@ static int stress_alloc_idx(struct stress_thread_info *info, int idx, unsigned l
     }
 
     if (down_interruptible(&info->ctx->sem)) {
-         printk(KERN_DEBUG "[STRESS %d] ALLOC interrupted idx=%d addr=%px active_total=%ld active_thread=%lu\n",
+          pr_debug("[STRESS %d] ALLOC interrupted idx=%d addr=%px active_total=%ld active_thread=%lu\n",
                info->id, idx, (void *)cur_addr,
              atomic_long_read(&info->ctx->active_allocs),
              info->active_owned);
@@ -188,12 +209,18 @@ static int stress_alloc_idx(struct stress_thread_info *info, int idx, unsigned l
 
     info->alloc_retries += retry_count;
     if (IS_ERR(pg) || !pg) {
-         printk(KERN_DEBUG "[STRESS %d] ALLOC FAILED idx=%d addr=%px retries=%d active_total=%ld active_thread=%lu\n",
+          pr_debug("[STRESS %d] ALLOC FAILED idx=%d addr=%px retries=%d active_total=%ld active_thread=%lu\n",
              info->id, idx, (void *)cur_addr, retry_count,
              atomic_long_read(&info->ctx->active_allocs),
              info->active_owned);
         info->alloc_fail++;
-        info->had_error = 1;
+        /*
+         * -EAGAIN means the cache is full and no eviction could complete within
+         * the retry window -- an expected backoff under heavy eviction pressure,
+         * not a data-integrity failure. Only non-EAGAIN errors are fatal.
+         */
+        if (!IS_ERR(pg) || PTR_ERR(pg) != -EAGAIN)
+            info->had_error = 1;
         info->owned_pages[idx] = NULL;
         return IS_ERR(pg) ? (int)PTR_ERR(pg) : -ENOMEM;
     }
@@ -225,7 +252,7 @@ static int stress_refault_idx(struct stress_thread_info *info, int idx, unsigned
 
     prep_ret = stress_prepare_vmf(info->mm, cur_addr, &fake_vmf);
     if (prep_ret) {
-        printk(KERN_DEBUG "[STRESS %d] REFAULT VMA not found for idx=%d addr=%px\n",
+        pr_debug("[STRESS %d] REFAULT VMA not found for idx=%d addr=%px\n",
                info->id, idx, (void *)cur_addr);
         info->refault_fail++;
         info->had_error = 1;
@@ -263,15 +290,29 @@ static int stress_refault_idx(struct stress_thread_info *info, int idx, unsigned
     if (ret == -ENOENT) {
         /* Not evicted (no refault entry) is expected; count and move on. */
         info->refault_noent++;
+        atomic_inc(&rn_st_refault_enoent);
         return 0;
     }
     if (ret) {
-        printk(KERN_DEBUG "[STRESS %d] REFAULT FAILED idx=%d addr=%px ret=%d retries=%d\n",
+        if (ret == -EAGAIN)
+            atomic_inc(&rn_st_refault_eagain);
+        else
+            atomic_inc(&rn_st_refault_err);
+        pr_debug("[STRESS %d] REFAULT FAILED idx=%d addr=%px ret=%d retries=%d\n",
                info->id, idx, (void *)cur_addr, ret, retry_count);
         info->refault_fail++;
-        info->had_error = 1;
+        /*
+         * -EAGAIN means the refetch could not complete within the retry window --
+         * an expected backoff under heavy eviction pressure, not a
+         * data-integrity failure. Only non-EAGAIN errors are fatal.
+         */
+        if (ret != -EAGAIN)
+            info->had_error = 1;
         return ret;
     }
+
+    /* ret == 0: refault reported success */
+    atomic_inc(&rn_st_refault_ret0);
 
     /* Verify the page data after a successful refault. */
     if (info->expected_seed) {
@@ -281,11 +322,16 @@ static int stress_refault_idx(struct stress_thread_info *info, int idx, unsigned
         if (!seed)
             seed = stress_seed_for_addr(cur_addr);
         if (!stress_verify_page_pattern(info->owned_pages[idx], seed, &bad_off, &exp, &got)) {
-            printk(KERN_ERR "[STRESS %d] DATA CORRUPT idx=%d addr=%px off=%d exp=%u got=%u\n",
-                   info->id, idx, (void *)cur_addr, bad_off, exp, got);
             info->data_corrupt++;
             info->had_error = 1;
+            atomic_inc(&rn_st_ret0_corrupt);
+            printk(KERN_ERR "[STRESS %d] DATA CORRUPT idx=%d addr=%px off=%d exp=%u got=%u\n",
+                   info->id, idx, (void *)cur_addr, bad_off, exp, got);
+        } else {
+            atomic_inc(&rn_st_ret0_ok);
         }
+    } else {
+        atomic_inc(&rn_st_verify_none);
     }
     info->refault_success++;
     return 0;
@@ -323,7 +369,7 @@ static int stress_free_idx(struct stress_thread_info *info, int idx, unsigned lo
         return 0;
     }
     if (ret) {
-        printk(KERN_DEBUG "[STRESS %d] FREE FAILED idx=%d addr=%px ret=%d\n",
+        pr_debug("[STRESS %d] FREE FAILED idx=%d addr=%px ret=%d\n",
                info->id, idx, (void *)cur_addr, ret);
         info->free_fail++;
         info->had_error = 1;
@@ -346,7 +392,7 @@ static int stress_thread_fn(void *data) {
         // Use a semaphore to limit concurrent ops
         // (Initialized in run_stress_test)
     struct stress_thread_info *info = data;
-    unsigned long duration_jiffies = (unsigned long)REMOTE_NUMA_STRESS_MINUTES * 60 * HZ;
+    unsigned long duration_jiffies = (unsigned long)stress_minutes * 60 * HZ;
         unsigned long start_jiffies;
         unsigned long end_time;
     // Zero stats
@@ -363,7 +409,7 @@ static int stress_thread_fn(void *data) {
     info->free_fail = 0;
     info->free_noent = 0;
 
-	int cache_pages = REMOTE_NUMA_STRESS_CACHE_SIZE / REMOTE_NUMA_STRESS_THREADS;
+	int cache_pages = stress_cache_size / stress_threads;
 	if (cache_pages < 1)
 		cache_pages = 1;
 	int victim_pages = info->num_owned;
@@ -386,6 +432,22 @@ static int stress_thread_fn(void *data) {
         (void)stress_alloc_idx(info, idx, cur_addr);
     }
 
+    /*
+     * Barrier: ensure EVERY thread has finished its initial allocations -- and
+     * therefore written its victim pages' deterministic pattern -- before ANY
+     * thread enters the churn loop. The victim pattern is written after the
+     * allocation semaphore is released (stress_alloc_idx), and the sem is a
+     * counting semaphore, so without this barrier one thread's churn-phase
+     * allocation can evict (async-sync) another thread's victim page while that
+     * thread is still writing its initial pattern. The donor would then store a
+     * partially written page, and every later refault/verify of that victim
+     * reports permanent corruption (got=0 at a random offset).
+     */
+    atomic_inc(&info->ctx->initial_done);
+    while (atomic_read(&info->ctx->initial_done) <
+           atomic_read(&info->ctx->total_threads))
+        msleep(1);
+
     /* Start timing AFTER initial allocations so we actually stress for the full duration. */
     start_jiffies = jiffies;
     end_time = start_jiffies + duration_jiffies;
@@ -395,10 +457,10 @@ static int stress_thread_fn(void *data) {
     // Main stress phase: deterministic bursts to force eviction/refault/free
     while (time_before(jiffies, end_time) && !kthread_should_stop()) {
         if ((jiffies % HZ) == 0) {
-            printk(KERN_DEBUG "[STRESS %d] jiffies=%lu (seconds elapsed: %lu/%d)\n", info->id, jiffies, (jiffies - start_jiffies) / HZ, REMOTE_NUMA_STRESS_MINUTES * 60);
+            pr_debug("[STRESS %d] jiffies=%lu (seconds elapsed: %lu/%d)\n", info->id, jiffies, (jiffies - start_jiffies) / HZ, stress_minutes * 60);
         }
 		/* 1) Churn alloc burst: allocate pages beyond cache size to force evictions */
-		for (int i = 0; i < REMOTE_NUMA_STRESS_BURST_OPS && churn_pages > 0; i++) {
+		for (int i = 0; i < stress_burst_ops && churn_pages > 0; i++) {
 			int idx = churn_alloc_cursor;
 			unsigned long cur_addr;
 			churn_alloc_cursor++;
@@ -409,7 +471,7 @@ static int stress_thread_fn(void *data) {
 		}
 
 		/* 2) Refault burst: try victims; -ENOENT means not evicted (expected) */
-		for (int i = 0; i < REMOTE_NUMA_STRESS_BURST_OPS && victim_pages > 0; i++) {
+		for (int i = 0; i < stress_burst_ops && victim_pages > 0; i++) {
 			int idx = victim_cursor;
 			unsigned long cur_addr;
 			victim_cursor++;
@@ -420,7 +482,7 @@ static int stress_thread_fn(void *data) {
 		}
 
 		/* 3) Churn free burst: free some churn pages so we can re-alloc and keep pressure */
-		for (int i = 0; i < REMOTE_NUMA_STRESS_BURST_OPS && churn_pages > 0; i++) {
+		for (int i = 0; i < stress_burst_ops && churn_pages > 0; i++) {
 			int idx = churn_free_cursor;
 			unsigned long cur_addr;
 			churn_free_cursor++;
@@ -452,10 +514,11 @@ static int stress_thread_fn(void *data) {
 
 static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr, struct mm_struct *mm) {
     struct stress_test_ctx ctx;
-    sema_init(&ctx.sem, REMOTE_NUMA_STRESS_MAX_CONCURRENT_OPS);
+    sema_init(&ctx.sem, stress_max_concurrent);
     atomic_long_set(&ctx.active_allocs, 0);
+    atomic_set(&ctx.initial_done, 0);
     // Validate address range is covered by contiguous VMAs; clamp to what is mapped.
-    unsigned long requested_end = addr + (unsigned long)REMOTE_NUMA_STRESS_TEST_PAGES * PAGE_SIZE;
+    unsigned long requested_end = addr + (unsigned long)stress_test_pages * PAGE_SIZE;
     unsigned long covered_end = addr;
     struct vm_area_struct *vma = NULL;
     struct vma_iterator vmi;
@@ -489,7 +552,7 @@ static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr
     }
 
     unsigned long available_pages = (covered_end - addr) / PAGE_SIZE;
-    unsigned long test_pages = REMOTE_NUMA_STRESS_TEST_PAGES;
+    unsigned long test_pages = stress_test_pages;
     if (available_pages < test_pages) {
         printk(KERN_WARNING "[STRESS TEST] Requested %lu pages (%px - %px) but only %lu pages are mapped contiguously (%px - %px). Clamping.\n",
                test_pages, (void *)addr, (void *)requested_end,
@@ -497,10 +560,10 @@ static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr
         test_pages = available_pages;
     }
 
-    if (test_pages % REMOTE_NUMA_STRESS_THREADS) {
-        unsigned long new_pages = (test_pages / REMOTE_NUMA_STRESS_THREADS) * REMOTE_NUMA_STRESS_THREADS;
+    if (test_pages % stress_threads) {
+        unsigned long new_pages = (test_pages / stress_threads) * stress_threads;
         printk(KERN_WARNING "[STRESS TEST] test_pages (%lu) not divisible by threads (%d); clamping to %lu pages\n",
-               test_pages, REMOTE_NUMA_STRESS_THREADS, new_pages);
+               test_pages, stress_threads, new_pages);
         test_pages = new_pages;
     }
     if (!test_pages) {
@@ -508,12 +571,12 @@ static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr
         return -EINVAL;
     }
 
-    if (test_pages <= REMOTE_NUMA_STRESS_CACHE_SIZE) {
-        printk(KERN_WARNING "[STRESS TEST] test_pages=%lu <= cache_size=%d; evictions/refaults may be rare or absent. Increase userspace mapping or REMOTE_NUMA_STRESS_TEST_PAGES.\n",
-               test_pages, REMOTE_NUMA_STRESS_CACHE_SIZE);
+    if (test_pages <= stress_cache_size) {
+        printk(KERN_WARNING "[STRESS TEST] test_pages=%lu <= cache_size=%d; evictions/refaults may be rare or absent. Increase userspace mapping or stress_test_pages.\n",
+               test_pages, stress_cache_size);
     }
 
-    struct stress_thread_info *thread_infos = kzalloc(sizeof(*thread_infos) * REMOTE_NUMA_STRESS_THREADS, GFP_KERNEL);
+    struct stress_thread_info *thread_infos = kzalloc(sizeof(*thread_infos) * stress_threads, GFP_KERNEL);
     if (!thread_infos) {
         printk(KERN_ERR "[STRESS TEST] Failed to allocate thread_infos\n");
         return -ENOMEM;
@@ -534,8 +597,8 @@ static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr
         return -ENOMEM;
     }
     // Partition pages among threads
-    int pages_per_thread = test_pages / REMOTE_NUMA_STRESS_THREADS;
-    for (int t = 0; t < REMOTE_NUMA_STRESS_THREADS; t++) {
+    int pages_per_thread = test_pages / stress_threads;
+    for (int t = 0; t < stress_threads; t++) {
         thread_infos[t].id = t;
         thread_infos[t].cache = cache;
         thread_infos[t].ctx = &ctx;
@@ -552,38 +615,56 @@ static int run_stress_test(remote_numa_client_cache_t *cache, unsigned long addr
      * treated as a real struct page* by refault/free, causing massive failures.
      * Each thread performs its own robust initial allocation with retries.
      */
-    // Start threads
-    for (int t = 0; t < REMOTE_NUMA_STRESS_THREADS; t++) {
+    // Start threads.
+    //
+    // total_threads is published before any thread runs so the initial-phase
+    // barrier in stress_thread_fn knows exactly how many peers to wait for.
+    // If a thread fails to start we decrement the expected count so the
+    // barrier cannot deadlock waiting for a peer that will never arrive.
+    atomic_set(&ctx.total_threads, stress_threads);
+    for (int t = 0; t < stress_threads; t++) {
         init_completion(&thread_infos[t].done);
         thread_infos[t].task = kthread_run(stress_thread_fn, &thread_infos[t], "numa_stress_%d", t);
+        if (IS_ERR(thread_infos[t].task)) {
+            printk(KERN_ERR "[STRESS TEST] Failed to start thread %d (%ld); continuing with fewer threads\n",
+                   t, PTR_ERR(thread_infos[t].task));
+            atomic_dec(&ctx.total_threads);
+        }
+    }
+    if (!atomic_read(&ctx.total_threads)) {
+        printk(KERN_ERR "[STRESS TEST] No stress threads started\n");
+        kfree(all_expected);
+        kfree(all_pages);
+        kfree(thread_infos);
+        return -EIO;
     }
 
     /*
      * Wait for threads to finish their full-duration stress phase.
      * (Duration starts after initial alloc inside the thread.)
      */
-    for (int t = 0; t < REMOTE_NUMA_STRESS_THREADS; t++) {
+    for (int t = 0; t < stress_threads; t++) {
         if (thread_infos[t].task) {
-            unsigned long timeout = ((unsigned long)REMOTE_NUMA_STRESS_MINUTES * 60 + 30) * HZ;
+            unsigned long timeout = ((unsigned long)stress_minutes * 60 + 30) * HZ;
             if (!wait_for_completion_timeout(&thread_infos[t].done, timeout))
                 printk(KERN_WARNING "[STRESS TEST] Thread %d did not finish before timeout; stopping\n", t);
         }
     }
 
     /* Stop/join threads for cleanup (also releases kthread resources). */
-    for (int t = 0; t < REMOTE_NUMA_STRESS_THREADS; t++) {
+    for (int t = 0; t < stress_threads; t++) {
         if (thread_infos[t].task)
             kthread_stop(thread_infos[t].task);
     }
     int any_error = 0;
-    for (int t = 0; t < REMOTE_NUMA_STRESS_THREADS; t++) {
+    for (int t = 0; t < stress_threads; t++) {
         if (thread_infos[t].had_error) {
             any_error = 1;
             printk(KERN_ERR "[STRESS TEST] Thread %d encountered errors!\n", t);
         }
     }
     if (!any_error)
-        printk(KERN_INFO "[STRESS TEST] Completed %d threads for %d minutes with no errors\n", REMOTE_NUMA_STRESS_THREADS, REMOTE_NUMA_STRESS_MINUTES);
+        printk(KERN_INFO "[STRESS TEST] Completed %d threads for %d minutes with no errors\n", stress_threads, stress_minutes);
     else
         printk(KERN_ERR "[STRESS TEST] Errors occurred during stress test!\n");
     kfree(all_pages);

--- a/drivers/staging/remote_numa/rn_counters.c
+++ b/drivers/staging/remote_numa/rn_counters.c
@@ -1,0 +1,168 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/atomic.h>
+#include <linux/debugfs.h>
+#include <linux/seq_file.h>
+#include "rn_counters.h"
+
+/* ---- transport: is_transfer_complete() ---- */
+atomic_t rn_tc_call;
+atomic_t rn_tc_no_xfer;
+atomic_t rn_tc_no_xfer_done;
+atomic_t rn_tc_no_xfer_wip;
+atomic_t rn_tc_xfer_present;
+atomic_t rn_tc_xfer_done;
+atomic_t rn_tc_xfer_notdone;
+atomic_long_t rn_tc_xfer_last_mc;
+atomic_t rn_tc_stale;
+atomic_t rn_tc_stale_done;
+atomic_t rn_tc_stale_notdone;
+atomic_t rn_tc_removed;
+atomic_t rn_tc_removed_skip;
+
+/* ---- client_cache: refault() ---- */
+atomic_t rn_rf_enter;
+atomic_t rn_rf_existing;
+atomic_t rn_rf_existing_done;
+atomic_t rn_rf_existing_wip;
+atomic_t rn_rf_existing_err;
+atomic_t rn_rf_evict_eagain;
+atomic_t rn_rf_evict_enomem;
+atomic_t rn_rf_noent;
+atomic_t rn_rf_reuse_eagain;
+atomic_t rn_rf_reuse_enomem;
+atomic_t rn_rf_kp_null;
+atomic_t rn_rf_refetch_eio;
+atomic_t rn_rf_refetch_start;
+
+/* ---- transfer-path diagnostics ---- */
+atomic_t rn_dnh_enter;
+atomic_t rn_dnh_noent;
+atomic_t rn_dnh_send;
+atomic_t rn_dnh_first_zero;
+atomic_t rn_mrs_send;
+atomic_t rn_sync_skip;
+atomic_t rn_ack_drop_nf;
+atomic_t rn_ack_drop_hack;
+atomic_t rn_dmf_fail;
+atomic_t rn_mrw_write;
+atomic_t rn_mrw_first_zero;
+
+/* ---- test module: stress outcomes ---- */
+atomic_t rn_st_refault_ret0;
+atomic_t rn_st_refault_eagain;
+atomic_t rn_st_refault_enoent;
+atomic_t rn_st_refault_err;
+atomic_t rn_st_ret0_ok;
+atomic_t rn_st_ret0_corrupt;
+atomic_t rn_st_verify_none;
+
+/* Export the stress-outcome counters so the (separate) test module can use
+ * them. The transport/client_cache counters stay intra-core. */
+EXPORT_SYMBOL_GPL(rn_st_refault_ret0);
+EXPORT_SYMBOL_GPL(rn_st_refault_eagain);
+EXPORT_SYMBOL_GPL(rn_st_refault_enoent);
+EXPORT_SYMBOL_GPL(rn_st_refault_err);
+EXPORT_SYMBOL_GPL(rn_st_ret0_ok);
+EXPORT_SYMBOL_GPL(rn_st_ret0_corrupt);
+EXPORT_SYMBOL_GPL(rn_st_verify_none);
+
+static int rn_counters_show(struct seq_file *m, void *v)
+{
+	seq_puts(m, "remote_numa counters\n");
+	seq_puts(m, "transport is_transfer_complete:\n");
+	seq_printf(m, "  rn_tc_call=%d\n",        atomic_read(&rn_tc_call));
+	seq_printf(m, "  rn_tc_no_xfer=%d\n",     atomic_read(&rn_tc_no_xfer));
+	seq_printf(m, "  rn_tc_no_xfer_done=%d\n",  atomic_read(&rn_tc_no_xfer_done));
+	seq_printf(m, "  rn_tc_no_xfer_wip=%d\n",   atomic_read(&rn_tc_no_xfer_wip));
+	seq_printf(m, "  rn_tc_xfer_present=%d\n",  atomic_read(&rn_tc_xfer_present));
+	seq_printf(m, "  rn_tc_xfer_done=%d\n",     atomic_read(&rn_tc_xfer_done));
+	seq_printf(m, "  rn_tc_xfer_notdone=%d\n",  atomic_read(&rn_tc_xfer_notdone));
+	seq_printf(m, "  rn_tc_xfer_last_mc=%ld\n", atomic_long_read(&rn_tc_xfer_last_mc));
+	seq_printf(m, "  rn_tc_stale=%d\n",         atomic_read(&rn_tc_stale));
+	seq_printf(m, "  rn_tc_stale_done=%d\n",    atomic_read(&rn_tc_stale_done));
+	seq_printf(m, "  rn_tc_stale_notdone=%d\n", atomic_read(&rn_tc_stale_notdone));
+	seq_printf(m, "  rn_tc_removed=%d\n",       atomic_read(&rn_tc_removed));
+	seq_printf(m, "  rn_tc_removed_skip=%d\n",  atomic_read(&rn_tc_removed_skip));
+
+	seq_puts(m, "client_cache refault:\n");
+	seq_printf(m, "  rn_rf_enter=%d\n",          atomic_read(&rn_rf_enter));
+	seq_printf(m, "  rn_rf_existing=%d\n",       atomic_read(&rn_rf_existing));
+	seq_printf(m, "  rn_rf_existing_done=%d\n",  atomic_read(&rn_rf_existing_done));
+	seq_printf(m, "  rn_rf_existing_wip=%d\n",   atomic_read(&rn_rf_existing_wip));
+	seq_printf(m, "  rn_rf_existing_err=%d\n",   atomic_read(&rn_rf_existing_err));
+	seq_printf(m, "  rn_rf_evict_eagain=%d\n",   atomic_read(&rn_rf_evict_eagain));
+	seq_printf(m, "  rn_rf_evict_enomem=%d\n",   atomic_read(&rn_rf_evict_enomem));
+	seq_printf(m, "  rn_rf_noent=%d\n",          atomic_read(&rn_rf_noent));
+	seq_printf(m, "  rn_rf_reuse_eagain=%d\n",   atomic_read(&rn_rf_reuse_eagain));
+	seq_printf(m, "  rn_rf_reuse_enomem=%d\n",   atomic_read(&rn_rf_reuse_enomem));
+	seq_printf(m, "  rn_rf_kp_null=%d\n",        atomic_read(&rn_rf_kp_null));
+	seq_printf(m, "  rn_rf_refetch_eio=%d\n",    atomic_read(&rn_rf_refetch_eio));
+	seq_printf(m, "  rn_rf_refetch_start=%d\n",  atomic_read(&rn_rf_refetch_start));
+
+	seq_puts(m, "transfer-path diagnostics:\n");
+	seq_printf(m, "  rn_dnh_enter=%d\n",        atomic_read(&rn_dnh_enter));
+	seq_printf(m, "  rn_dnh_noent=%d\n",        atomic_read(&rn_dnh_noent));
+	seq_printf(m, "  rn_dnh_send=%d\n",         atomic_read(&rn_dnh_send));
+	seq_printf(m, "  rn_dnh_first_zero=%d\n",   atomic_read(&rn_dnh_first_zero));
+	seq_printf(m, "  rn_mrs_send=%d\n",         atomic_read(&rn_mrs_send));
+	seq_printf(m, "  rn_sync_skip=%d\n",        atomic_read(&rn_sync_skip));
+	seq_printf(m, "  rn_ack_drop_nf=%d\n",      atomic_read(&rn_ack_drop_nf));
+	seq_printf(m, "  rn_ack_drop_hack=%d\n",    atomic_read(&rn_ack_drop_hack));
+	seq_printf(m, "  rn_dmf_fail=%d\n",         atomic_read(&rn_dmf_fail));
+	seq_printf(m, "  rn_mrw_write=%d\n",        atomic_read(&rn_mrw_write));
+	seq_printf(m, "  rn_mrw_first_zero=%d\n",   atomic_read(&rn_mrw_first_zero));
+
+	seq_puts(m, "stress outcomes:\n");
+	seq_printf(m, "  rn_st_refault_ret0=%d\n",   atomic_read(&rn_st_refault_ret0));
+	seq_printf(m, "  rn_st_refault_eagain=%d\n", atomic_read(&rn_st_refault_eagain));
+	seq_printf(m, "  rn_st_refault_enoent=%d\n", atomic_read(&rn_st_refault_enoent));
+	seq_printf(m, "  rn_st_refault_err=%d\n",    atomic_read(&rn_st_refault_err));
+	seq_printf(m, "  rn_st_ret0_ok=%d\n",        atomic_read(&rn_st_ret0_ok));
+	seq_printf(m, "  rn_st_ret0_corrupt=%d\n",   atomic_read(&rn_st_ret0_corrupt));
+	seq_printf(m, "  rn_st_verify_none=%d\n",   atomic_read(&rn_st_verify_none));
+	return 0;
+}
+
+static int rn_counters_open(struct inode *inode, struct file *file)
+{
+	return single_open(file, rn_counters_show, NULL);
+}
+
+static const struct file_operations rn_counters_fops = {
+	.owner   = THIS_MODULE,
+	.open    = rn_counters_open,
+	.read    = seq_read,
+	.llseek  = seq_lseek,
+	.release = single_release,
+};
+
+static struct dentry *rn_dbg_root;
+static struct dentry *rn_dbg_counters;
+
+int rn_counters_init(void)
+{
+	rn_dbg_root = debugfs_create_dir("remote_numa", NULL);
+	if (IS_ERR(rn_dbg_root))
+		return PTR_ERR(rn_dbg_root);
+
+	rn_dbg_counters = debugfs_create_file("counters", 0444, rn_dbg_root,
+					      NULL, &rn_counters_fops);
+	if (IS_ERR(rn_dbg_counters)) {
+		debugfs_remove(rn_dbg_root);
+		rn_dbg_root = NULL;
+		return PTR_ERR(rn_dbg_counters);
+	}
+	return 0;
+}
+
+void rn_counters_exit(void)
+{
+	debugfs_remove(rn_dbg_counters);
+	debugfs_remove(rn_dbg_root);
+	rn_dbg_counters = NULL;
+	rn_dbg_root = NULL;
+}
+
+module_init(rn_counters_init);
+module_exit(rn_counters_exit);

--- a/drivers/staging/remote_numa/rn_counters.h
+++ b/drivers/staging/remote_numa/rn_counters.h
@@ -1,0 +1,81 @@
+#ifndef REMOTE_NUMA_RN_COUNTERS_H
+#define REMOTE_NUMA_RN_COUNTERS_H
+
+#include <linux/types.h>
+#include <linux/atomic.h>
+
+/*
+ * Hyper-specific diagnostic counters for the remote_numa refault/transfer
+ * path.
+ *
+ * They are global (defined in rn_counters.c) so any core-module file can
+ * increment them directly, and the exported ones can be incremented from the
+ * test module. All of them are dumped on demand through the debugfs file:
+ *
+ *     /sys/kernel/debug/remote_numa/counters
+ *
+ * No printk is used for the high-frequency paths; the counters accumulate and
+ * are read on demand, so they cannot be silenced by a corrupted log gate.
+ */
+
+/* ---- transport: remote_numa_transport_is_transfer_complete() ---- */
+extern atomic_t rn_tc_call;        /* total calls to is_transfer_complete   */
+extern atomic_t rn_tc_no_xfer;     /* xfer_get() returned NULL              */
+extern atomic_t rn_tc_no_xfer_done;/* no-xfer && tip==0  -> returns true    */
+extern atomic_t rn_tc_no_xfer_wip; /* no-xfer && tip!=0  -> returns false   */
+extern atomic_t rn_tc_xfer_present;/* xfer_get() returned a xfer            */
+extern atomic_t rn_tc_xfer_done;   /* xfer && max_contig>=PAGE -> true      */
+extern atomic_t rn_tc_xfer_notdone;/* xfer && max_contig< PAGE -> false     */
+extern atomic_long_t rn_tc_xfer_last_mc; /* last max_contig (not-done case) */
+extern atomic_t rn_tc_stale;       /* xfer->cached_pg != cached_target      */
+extern atomic_t rn_tc_stale_done;  /* stale && done (premature complete)    */
+extern atomic_t rn_tc_stale_notdone;/* stale && !done                       */
+extern atomic_t rn_tc_removed;     /* removed a completed xfer from table   */
+extern atomic_t rn_tc_removed_skip;/* xfer already not hashed on remove     */
+
+/* ---- client_cache: remote_numa_client_cache_refault() ---- */
+extern atomic_t rn_rf_enter;       /* function entries                      */
+extern atomic_t rn_rf_existing;    /* existing (mm,addr) entry found        */
+extern atomic_t rn_rf_existing_done;/* existing && complete -> return 0     */
+extern atomic_t rn_rf_existing_wip;/* existing && !complete && in-progress  */
+extern atomic_t rn_rf_existing_err;/* existing && !complete && !in-progress */
+extern atomic_t rn_rf_evict_eagain;/* maybe_evict -> -EAGAIN                */
+extern atomic_t rn_rf_evict_enomem;/* maybe_evict -> other error            */
+extern atomic_t rn_rf_noent;       /* refault_table_consume failed          */
+extern atomic_t rn_rf_reuse_eagain;/* reuse_page fail, evict -EAGAIN/0      */
+extern atomic_t rn_rf_reuse_enomem;/* reuse_page fail, evict other          */
+extern atomic_t rn_rf_kp_null;     /* known_pages_lookup returned NULL      */
+extern atomic_t rn_rf_refetch_eio; /* refetch_page_async failed             */
+extern atomic_t rn_rf_refetch_start;/* refetch started -> return -EAGAIN    */
+
+/* ---- transfer-path diagnostics (replaces bounded printk litter) ----
+ * These live on both nodes; each node's debugfs shows its own counters.
+ * The *_first_zero counters flag a page whose first byte is 0, a strong
+ * indicator of a zeroed/wrong page being sent or received (corruption).
+ */
+extern atomic_t rn_dnh_enter;        /* donor refetch handler ENTER           */
+extern atomic_t rn_dnh_noent;        /* donor refetch handler: page not found */
+extern atomic_t rn_dnh_send;         /* donor refetch handler: sent a page    */
+extern atomic_t rn_dnh_first_zero;   /* donor sent page with first byte == 0  */
+extern atomic_t rn_mrs_send;         /* main: refetch_page_async issued       */
+extern atomic_t rn_sync_skip;        /* mem_sync copy skipped (page missing)  */
+extern atomic_t rn_ack_drop_nf;      /* sat_ack dropped: xfer not found       */
+extern atomic_t rn_ack_drop_hack;    /* sat_ack dropped: hack mismatch        */
+extern atomic_t rn_dmf_fail;         /* donor mem_alloc failed (no page)      */
+extern atomic_t rn_mrw_write;        /* main: sat payload written to target   */
+extern atomic_t rn_mrw_first_zero;   /* main: received first byte == 0        */
+
+/* ---- test module: stress outcomes (globals survive per-thread resets) ---- */
+extern atomic_t rn_st_refault_ret0;  /* refault returned 0                  */
+extern atomic_t rn_st_refault_eagain;/* refault returned -EAGAIN (final)    */
+extern atomic_t rn_st_refault_enoent;/* refault returned -ENOENT            */
+extern atomic_t rn_st_refault_err;   /* refault returned other error        */
+extern atomic_t rn_st_ret0_ok;       /* ret==0 and page verified good       */
+extern atomic_t rn_st_ret0_corrupt;  /* ret==0 and page verified BAD        */
+extern atomic_t rn_st_verify_none;   /* ret==0 but no seed to verify        */
+
+/* debugfs plumbing (lives in the core module) */
+int  rn_counters_init(void);
+void rn_counters_exit(void);
+
+#endif /* REMOTE_NUMA_RN_COUNTERS_H */

--- a/drivers/staging/remote_numa/transport.c
+++ b/drivers/staging/remote_numa/transport.c
@@ -16,21 +16,37 @@
 
 #include "memory.h"
 #include "transport.h"
+#include "rn_counters.h"
 
 #define REMOTE_NUMA_SUPPORTED_PROTO  remote_numa_protocol_0_1
 #define REMOTE_NUMA_XFER_HASH_BITS 12
 #define REMOTE_NUMA_REXMIT_CHECK_MS 10
 
 #define REMOTE_NUMA_TRANSFER_TIMEOUT_MS 1000
-#define REMOTE_NUMA_DEFAUKT_RETRY_INTERVAL_MS 5
-#define REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS (REMOTE_NUMA_DEFAUKT_RETRY_INTERVAL_MS * NSEC_PER_MSEC)
-#define REMOTE_NUMA_MAX_RETRY_COUNT 20
+static u32 retry_interval_ms = 5;
+module_param(retry_interval_ms, uint, 0644);
+MODULE_PARM_DESC(retry_interval_ms, "Base interval between retries in ms");
+static u32 max_retry_count = 20;
+module_param(max_retry_count, uint, 0644);
+MODULE_PARM_DESC(max_retry_count, "Max number of retries");
 
 DEFINE_HASHTABLE(xfer_table, REMOTE_NUMA_XFER_HASH_BITS);
 
 #include <linux/atomic.h>
-static spinlock_t hacky_spinlock;
-static int hack;
+#include <linux/rcupdate.h>
+/*
+ * xfer_table is an RCU-protected hash table. Readers walk it under
+ * rcu_read_lock() without taking a lock; only the rare insert/remove takes
+ * xfer_table_lock, briefly, to serialize the list mutation (hash_add_rcu /
+ * hash_del_rcu). Reclamation is deferred with call_rcu() so an in-flight
+ * reader can never touch a freed xfer. The "hack" tag counter is an atomic.
+ * Individual transfers' mutable state is protected by their own
+ * main_xfer_state_t::xfer_lock. Lock ordering (no inversions):
+ *     xfer_table_lock  (outer, brief, writers only)
+ *       -> xfer->xfer_lock  (inner)
+ */
+static spinlock_t xfer_table_lock;
+static atomic_t hack;
 
 
 typedef struct main_xfer_state {
@@ -59,6 +75,21 @@ typedef struct main_xfer_state {
 	unsigned long sent_bitmap[BITS_TO_LONGS(PAGE_SIZE)];
 
 	void *return_info;
+
+	/* RCU reclamation head; freed via call_rcu() after the last ref drops. */
+	struct rcu_head rcu;
+
+	/* Transient link used only while the retry worker collects candidates. */
+	struct list_head retry_link;
+
+	/*
+	 * Per-transfer lock. Protects this xfer's mutable state: the
+	 * received/sent bitmaps, retry_count/retry_deadline, and the hack tag.
+	 * The global xfer_table_lock (outer) serializes hash-table mutations
+	 * (hash_add_rcu / hash_del_rcu); whenever both are needed the table
+	 * lock is taken first, then the xfer lock.
+	 */
+	spinlock_t xfer_lock;
 } main_xfer_state_t;
 
 struct retry_work_item {
@@ -151,31 +182,23 @@ static u32 xfer_compute_max_contig(main_xfer_state_t *x)
 	return ret;
 }
 
-static int remote_numa_xfer_wait_complete(main_xfer_state_t *xfer, unsigned long timeout_jiffies)
-{
-	int ret = wait_event_timeout(
-		xfer->waitq,
-		xfer_compute_max_contig(xfer) >= PAGE_SIZE,
-		timeout_jiffies) > 0 ? 0 : -ETIMEDOUT;
-	return ret;
-}
-
 static inline u32 xfer_hash(u64 cookie)
 {
 	return hash_64(cookie, REMOTE_NUMA_XFER_HASH_BITS);
 }
 
-static void xfer_free(main_xfer_state_t *xfer)
+static void xfer_free_rcu(struct rcu_head *rcu)
 {
+	main_xfer_state_t *xfer = container_of(rcu, main_xfer_state_t, rcu);
 	struct remote_numa_cached_page *cached = xfer->cached_pg;
-	
+
 	// Free cached_pg if it was allocated for mem_free tracking
 	if (xfer->transfer_type == remote_numa_mem_free && cached)
 	{
 		kfree(cached->known_page);
 		kfree(cached);
 	}
-	
+
 	kfree(xfer);
 }
 
@@ -184,23 +207,31 @@ static void xfer_put(main_xfer_state_t *xfer)
 	if (!xfer)
 		return;
 	if (refcount_dec_and_test(&xfer->refcnt))
-		xfer_free(xfer);
+		call_rcu(&xfer->rcu, xfer_free_rcu);
 }
 
 static main_xfer_state_t *xfer_get(u64 cookie)
 {
 	main_xfer_state_t *xfer;
 
-	spin_lock(&hacky_spinlock);
-	hash_for_each_possible(xfer_table, xfer, node, xfer_hash(cookie)) {
+	/*
+	 * RCU read-side: walk the table lock-free. refcount_inc_not_zero() is
+	 * atomic and safe to call here; a concurrently-reclaimed xfer either
+	 * still has the table reference (so the inc succeeds and our own
+	 * reference keeps it alive) or is already freed (refcount 0 -> the inc
+	 * fails and we keep walking). call_rcu() guarantees a freed xfer stays
+	 * allocated for the duration of this RCU read section.
+	 */
+	rcu_read_lock();
+	hash_for_each_possible_rcu(xfer_table, xfer, node, xfer_hash(cookie)) {
 		if (((u64)cookie) != xfer->lookup_cookie)
 			continue;
 		if (!refcount_inc_not_zero(&xfer->refcnt))
 			continue;
-		spin_unlock(&hacky_spinlock);
+		rcu_read_unlock();
 		return xfer;
 	}
-	spin_unlock(&hacky_spinlock);
+	rcu_read_unlock();
 	return NULL;
 }
 
@@ -266,7 +297,7 @@ static int remote_numa_send_segment(main_xfer_state_t *xfer, u32 offset, u16 seg
 	alloc_tx_buffer(xfer, sizeof(*msg) + payload_len, &tx_buf, v);
 	if (!tx_buf || !msg)
 		return -ENOMEM;
-	spin_lock(&hacky_spinlock);
+	spin_lock(&xfer->xfer_lock);
 
 	msg->hdr.version = REMOTE_NUMA_SUPPORTED_PROTO;
 	msg->hdr.type = xfer->transfer_type;
@@ -278,12 +309,14 @@ static int remote_numa_send_segment(main_xfer_state_t *xfer, u32 offset, u16 seg
 	msg->sender_pg_cookie = xfer->cached_pg->main_pg_cookie;
 	msg->receiver_pg_cookie = xfer->cached_pg->known_page->donor_pg_cookie;
 	msg->hack = xfer->hack;
-	spin_unlock(&hacky_spinlock);
+	spin_unlock(&xfer->xfer_lock);
 
 	void *payload = ((u8 *)msg) + sizeof(*msg);
 	memcpy(payload, data + offset, payload_len);
 
+	spin_lock(&xfer->xfer_lock);
 	set_bit(offset / seg_len, xfer->sent_bitmap);
+	spin_unlock(&xfer->xfer_lock);
 
 	int ret = tx_msg(xfer, tx_buf);
 
@@ -294,69 +327,96 @@ static void remote_numa_retry_xfers(struct work_struct *work)
 {
 	if (hash_empty(xfer_table)) {
 		schedule_delayed_work(&remote_numa_retry_work,
-			msecs_to_jiffies(REMOTE_NUMA_DEFAUKT_RETRY_INTERVAL_MS));
+			msecs_to_jiffies(retry_interval_ms));
 		return;
 	}
 
 	u64 now_ns = ktime_get_ns();
 	main_xfer_state_t *xfer;
-	struct hlist_node *tmp;
+	main_xfer_state_t *tmp_xfer;
 	int bkt;
 	LIST_HEAD(work_list);
-	main_xfer_state_t **cleanup_array = NULL;
-	int cleanup_count = 0;
-	int cleanup_capacity = 16;
+	LIST_HEAD(candidates);
 
-	/* Use an array to store pointers to completed transfers to minimize lock hold time */
-	cleanup_array = kmalloc(cleanup_capacity * sizeof(*cleanup_array), GFP_KERNEL);
-	if (!cleanup_array) {
-		schedule_delayed_work(&remote_numa_retry_work,
-			msecs_to_jiffies(REMOTE_NUMA_DEFAUKT_RETRY_INTERVAL_MS));
-		return;
-	}
-
-	spin_lock(&hacky_spinlock);
-	hash_for_each_safe(xfer_table, bkt, tmp, xfer, node) {
+	/*
+	 * Phase 1: walk the table under RCU and grab a reference on every donor
+	 * xfer. Keep this section short - no bitmap scans, no allocation. The
+	 * reference keeps each xfer alive for the rest of this worker even if it
+	 * is concurrently removed from the table and freed.
+	 */
+	rcu_read_lock();
+	hash_for_each_rcu(xfer_table, bkt, xfer, node) {
 		if (xfer->is_main_node)
 			continue;
+		/*
+		 * Take a reference that keeps the xfer alive through phase 2.
+		 * inc_not_zero: if a concurrent completion already dropped the
+		 * last reference, the xfer is being reclaimed and we skip it.
+		 */
+		if (!refcount_inc_not_zero(&xfer->refcnt))
+			continue;
+		list_add(&xfer->retry_link, &candidates);
+	}
+	rcu_read_unlock();
 
-		if (xfer_compute_max_contig(xfer) >= PAGE_SIZE) {
-			hash_del(&xfer->node);
-			if (cleanup_count < cleanup_capacity)
-				cleanup_array[cleanup_count++] = xfer;
-			else /* Out of space in cleanup array, drop table ref now. */
+	/*
+	 * Phase 2: process the collected donor xfers. We hold a reference on
+	 * each, so they cannot be freed under us. The per-xfer lock guards the
+	 * mutable fields; the table lock is only taken briefly to remove a
+	 * finished or timed-out xfer.
+	 */
+	list_for_each_entry_safe(xfer, tmp_xfer, &candidates, retry_link) {
+		bool complete, timed_out, due;
+
+		spin_lock(&xfer->xfer_lock);
+		complete = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
+		timed_out = xfer->retry_count >= max_retry_count;
+		due = ktime_to_ns(xfer->retry_deadline) < now_ns;
+		spin_unlock(&xfer->xfer_lock);
+
+		if (complete || timed_out) {
+			bool removed = false;
+
+			if (timed_out)
+				printk(KERN_WARNING "remote_numa: donor xfer timeout\n");
+			spin_lock(&xfer_table_lock);
+			if (!hlist_unhashed(&xfer->node)) {
+				hash_del_rcu(&xfer->node);
+				removed = true;
+			}
+			spin_unlock(&xfer_table_lock);
+			/* Drop our phase-1 ref; also the table ref if we removed it. */
+			xfer_put(xfer);
+			if (removed)
 				xfer_put(xfer);
 			continue;
 		}
 
-		if (ktime_to_ns(xfer->retry_deadline) >= now_ns)
-			continue;
-
-		if (xfer->retry_count >= REMOTE_NUMA_MAX_RETRY_COUNT) {
-			printk(KERN_WARNING "remote_numa: donor xfer timeout\n");
-			hash_del(&xfer->node);
-			if (cleanup_count < cleanup_capacity)
-				cleanup_array[cleanup_count++] = xfer;
-			else
-				xfer_put(xfer);
+		if (!due) {
+			/* Not due yet; drop our phase-1 reference. */
+			xfer_put(xfer);
 			continue;
 		}
 
 		struct retry_work_item *item = kmalloc(sizeof(*item), GFP_ATOMIC);
 		if (item) {
-			/* Hold a reference while item lives beyond the table lock. */
+			/* item lives beyond this iteration; take an extra ref. */
 			refcount_inc(&xfer->refcnt);
 			item->xfer = xfer;
 			item->seg_len = xfer_state_max_payload(xfer) - sizeof(remote_numa_mem_pg_xfer_t);
 			list_add(&item->list, &work_list);
 		}
 
+		spin_lock(&xfer->xfer_lock);
 		xfer->retry_count++;
-		u64 base_interval = REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS << xfer->retry_count;
+		u64 base_interval = ((u64)retry_interval_ms * NSEC_PER_MSEC) << xfer->retry_count;
 		u64 jitter_ns = get_random_u32() % (base_interval / 10);
 		xfer->retry_deadline = ktime_add_ns(ktime_get(), base_interval + jitter_ns);
+		spin_unlock(&xfer->xfer_lock);
+
+		/* Drop our phase-1 reference. */
+		xfer_put(xfer);
 	}
-	spin_unlock(&hacky_spinlock);
 
 	struct retry_work_item *item, *item_tmp;
 	list_for_each_entry_safe(item, item_tmp, &work_list, list) {
@@ -373,12 +433,8 @@ static void remote_numa_retry_xfers(struct work_struct *work)
 		kfree(item);
 	}
 
-	for (int i = 0; i < cleanup_count; i++)
-		xfer_put(cleanup_array[i]);
-	kfree(cleanup_array);
-
 	schedule_delayed_work(&remote_numa_retry_work,
-		msecs_to_jiffies(REMOTE_NUMA_DEFAUKT_RETRY_INTERVAL_MS));
+		msecs_to_jiffies(retry_interval_ms));
 }
 
 static void remote_numa_start_retry_worker(void)
@@ -395,12 +451,69 @@ static void remote_numa_stop_retry_worker(void)
 bool remote_numa_transport_is_transfer_complete(
 	struct remote_numa_cached_page *cached_target)
 {
-	main_xfer_state_t *xfer = xfer_get((uintptr_t)cached_target);
-	if (!xfer)
-		return atomic_read(&cached_target->transfer_in_progress) == 0;
-	bool done = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
-	xfer_put(xfer);
-	return done;
+	atomic_inc(&rn_tc_call);
+	main_xfer_state_t *xfer = xfer_get(cached_target->xfer_cookie);
+	if (!xfer) {
+		bool r = atomic_read(&cached_target->transfer_in_progress) == 0;
+		atomic_inc(&rn_tc_no_xfer);
+		if (r)
+			atomic_inc(&rn_tc_no_xfer_done);
+		else
+			atomic_inc(&rn_tc_no_xfer_wip);
+		return r;
+	}
+	atomic_inc(&rn_tc_xfer_present);
+	{
+		unsigned long mc;
+		bool done;
+		bool stale;
+		spin_lock(&xfer->xfer_lock);
+		mc = xfer_compute_max_contig(xfer);
+		done = mc >= PAGE_SIZE;
+		stale = (xfer->cached_pg != cached_target);
+		spin_unlock(&xfer->xfer_lock);
+		if (done)
+			atomic_inc(&rn_tc_xfer_done);
+		else {
+			atomic_inc(&rn_tc_xfer_notdone);
+			atomic_long_set(&rn_tc_xfer_last_mc, (long)mc);
+		}
+		if (stale) {
+			atomic_inc(&rn_tc_stale);
+			if (done)
+				atomic_inc(&rn_tc_stale_done);
+			else
+				atomic_inc(&rn_tc_stale_notdone);
+		}
+		if (done) {
+			/*
+			 * Remove the completed main-side xfer from the table,
+			 * mirroring the alloc path
+			 * (remote_numa_check_transfer_complete). Otherwise the xfer
+			 * leaks and a reused entry address can make xfer_get()
+			 * return a stale completed xfer, causing a
+			 * premature-completion data corruption on a later transfer
+			 * of the same page.
+			 */
+			bool removed = false;
+			spin_lock(&xfer_table_lock);
+			if (!hlist_unhashed(&xfer->node)) {
+				hash_del_rcu(&xfer->node);
+				removed = true;
+			}
+			spin_unlock(&xfer_table_lock);
+			if (removed) {
+				atomic_inc(&rn_tc_removed);
+				if (xfer->cached_pg->xfer_cookie == xfer->lookup_cookie)
+					xfer->cached_pg->xfer_cookie = 0;
+				xfer_put(xfer); /* drop the table's reference */
+			} else {
+				atomic_inc(&rn_tc_removed_skip);
+			}
+		}
+		xfer_put(xfer); /* drop our lookup reference */
+		return done;
+	}
 }
 
 /* Pure lookup: caller must hold rcu_read_lock() */
@@ -443,6 +556,8 @@ static int remote_numa_rx_mem_pg_refetch(
 	remote_numa_mem_refetch_t *refetch,
 	u32 main_node_id)
 {
+	atomic_inc(&rn_dnh_enter);
+
 	struct remote_numa_mem_mgr *mgr = donor_if->trprt_ctx->mem;
 	if (!mgr)
 		return -EIO;
@@ -453,6 +568,7 @@ static int remote_numa_rx_mem_pg_refetch(
 	if (remote_numa_mem_lookup_page(mgr, refetch->donor_pg_cookie,
 	                                 &page_ptr, &rn_pg) != 0)
 	{
+		atomic_inc(&rn_dnh_noent);
 		return -ENOENT;
 	}
 	cached_pg = &rn_pg->cached_pg;
@@ -462,6 +578,11 @@ static int remote_numa_rx_mem_pg_refetch(
 	{
 		return -EIO;
 	}
+
+	/* Track whether the donor is sending a zeroed page (corruption indicator). */
+	atomic_inc(&rn_dnh_send);
+	if (((u8 *)page_ptr)[0] == 0)
+		atomic_inc(&rn_dnh_first_zero);
 
 	remote_numa_node_t *main_node = __remote_numa_get_node_locking(
 		donor_if->trprt_ctx->node_table,
@@ -476,6 +597,7 @@ static int remote_numa_rx_mem_pg_refetch(
 	if (!xfer)
 		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
+	spin_lock_init(&xfer->xfer_lock);
 
 	// TODO, this is super confusing, need to rename some fields.
 	// These donor/main pg cookies need to be backwards since
@@ -489,8 +611,12 @@ static int remote_numa_rx_mem_pg_refetch(
 	cached_pg->known_page->mm = NULL;
 	cached_pg->known_page->addr = 0;
 
-	spin_lock(&hacky_spinlock);
-	xfer->hack		= ++hack;
+	/*
+	 * The xfer is private (not yet in xfer_table), so initialize its fields
+	 * without a lock. Only the global hack counter and the table insertion
+	 * require the table lock. The wmb + table lock publish the fully
+	 * initialized xfer to concurrent xfer_get() lookups.
+	 */
 	xfer->cached_pg		= cached_pg;
 	xfer->lookup_cookie	= refetch->donor_pg_cookie;
 	xfer->hdr_main_cookie	= cached_pg->known_page->donor_id;
@@ -504,14 +630,17 @@ static int remote_numa_rx_mem_pg_refetch(
 	init_waitqueue_head(&xfer->waitq);
 	bitmap_zero(xfer->sent_bitmap, PAGE_SIZE);
 	bitmap_zero(xfer->received_bitmap, PAGE_SIZE);
-	u64 jitter_ns = get_random_u32() % (REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS / 10);
+	u64 jitter_ns = get_random_u32() % (((u64)retry_interval_ms * NSEC_PER_MSEC) / 10);
 	xfer->retry_deadline	= ktime_add_ns(ktime_get(),
-					   REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS + jitter_ns);
+					   ((u64)retry_interval_ms * NSEC_PER_MSEC) + jitter_ns);
 	xfer->retry_count	= 0;
 	smp_wmb();
-	hash_add(xfer_table, &xfer->node,
+
+	xfer->hack		= atomic_inc_return(&hack);
+	spin_lock(&xfer_table_lock);
+	hash_add_rcu(xfer_table, &xfer->node,
 		 xfer_hash(refetch->donor_pg_cookie));
-	spin_unlock(&hacky_spinlock);
+	spin_unlock(&xfer_table_lock);
 
 	u16 seg_len = donor_if->get_max_payload_len() -
 		      sizeof(remote_numa_mem_pg_xfer_t);
@@ -538,10 +667,15 @@ int remote_numa_transport_alloc_page_async(
 		return -ENOMEM;
 	}
 	refcount_set(&xfer->refcnt, 1);
+	spin_lock_init(&xfer->xfer_lock);
+
+	xfer->hack = atomic_inc_return(&hack);
+	xfer_hack = xfer->hack;
 
 	/* Prepare xfer state before publishing it in xfer_table. */
 	xfer->cached_pg = cached_target;
-	xfer->lookup_cookie = main_pg_cookie;
+	xfer->lookup_cookie = xfer->hack;
+	cached_target->xfer_cookie = xfer->hack;
 	xfer->cached_pg->known_page->donor_pg_cookie = 0;
 	xfer->cached_pg->main_pg_cookie = main_pg_cookie;
 	/* Keep a copy on the known_page so future frees can always recover it. */
@@ -559,28 +693,28 @@ int remote_numa_transport_alloc_page_async(
 	bitmap_zero(xfer->received_bitmap, PAGE_SIZE);
 	bitmap_zero(xfer->sent_bitmap, PAGE_SIZE);
 	{
-		u64 jitter_ns = get_random_u32() % (REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS / 10);
+		u64 jitter_ns = get_random_u32() % (((u64)retry_interval_ms * NSEC_PER_MSEC) / 10);
 		xfer->retry_deadline = ktime_add_ns(ktime_get(),
-					  REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS + jitter_ns);
+					  ((u64)retry_interval_ms * NSEC_PER_MSEC) + jitter_ns);
 	}
 	xfer->retry_count = 0;
 
 	/*
-	 * Keep hacky_spinlock held only while touching global xfer_table / hack.
-	 * Do not hold a spinlock across alloc_tx_buffer() or tx_msg().
+	 * The xfer is private here (fields set above); only the table insertion
+	 * needs the table lock. Do not hold a spinlock across
+	 * alloc_tx_buffer() or tx_msg().
 	 */
-	spin_lock(&hacky_spinlock);
-	xfer->hack = ++hack;
-	xfer_hack = xfer->hack;
-	hash_add(xfer_table, &xfer->node, xfer_hash(main_pg_cookie));
-	spin_unlock(&hacky_spinlock);
+	spin_lock(&xfer_table_lock);
+	hash_add_rcu(xfer_table, &xfer->node, xfer_hash(xfer->hack));
+	spin_unlock(&xfer_table_lock);
 
 	smp_wmb();
 	trprt->alloc_tx_buffer(sizeof(*req), &tx_buf, v);
 	if (!tx_buf || !req) {
-		spin_lock(&hacky_spinlock);
-		hash_del(&xfer->node);
-		spin_unlock(&hacky_spinlock);
+		cached_target->xfer_cookie = 0;
+		spin_lock(&xfer_table_lock);
+		hash_del_rcu(&xfer->node);
+		spin_unlock(&xfer_table_lock);
 		xfer_put(xfer);
 		return -ENOMEM;
 	}
@@ -589,13 +723,14 @@ int remote_numa_transport_alloc_page_async(
 	req->hdr.type = remote_numa_mem_alloc;
 	req->hdr.main_cookie = donor->node_id;
 	req->hdr.donor_cookie = donor->donor_cookie;
-	req->main_pg_cookie = main_pg_cookie;
+	req->main_pg_cookie = xfer->hack;
 	req->hack = xfer_hack;
 
 	if (trprt->tx_msg(trprt->trprt_ctx, donor->priv_return_info, tx_buf)) {
-		spin_lock(&hacky_spinlock);
-		hash_del(&xfer->node);
-		spin_unlock(&hacky_spinlock);
+		cached_target->xfer_cookie = 0;
+		spin_lock(&xfer_table_lock);
+		hash_del_rcu(&xfer->node);
+		spin_unlock(&xfer_table_lock);
 		xfer_put(xfer);
 		return -EIO;
 	}
@@ -610,6 +745,8 @@ int remote_numa_transport_refetch_page_async(
 	u64 donor_pg_cookie,
 	struct remote_numa_cached_page *cached_target)
 {
+	atomic_inc(&rn_mrs_send);
+
 	remote_numa_node_t *donor = NULL;
 
 	rcu_read_lock();
@@ -629,6 +766,7 @@ int remote_numa_transport_refetch_page_async(
 	if (!xfer)
 		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
+	spin_lock_init(&xfer->xfer_lock);
 
 	xfer->cached_pg = cached_target;
 	xfer->cached_pg->known_page->donor_pg_cookie = donor_pg_cookie;
@@ -640,29 +778,32 @@ int remote_numa_transport_refetch_page_async(
 	xfer->last_update = ktime_get();
 	xfer->cached_pg->main_pg_cookie = (uintptr_t)cached_target;
 	xfer->cached_pg->known_page->main_pg_cookie = xfer->cached_pg->main_pg_cookie;
-	xfer->lookup_cookie = (uintptr_t)cached_target;
+	xfer->hack = atomic_inc_return(&hack);
+	xfer->lookup_cookie = xfer->hack;
+	cached_target->xfer_cookie = xfer->hack;
 	xfer->main_trprt = trprt;
 	xfer->is_main_node = true;
 	xfer->return_info = donor->priv_return_info;
 	init_waitqueue_head(&xfer->waitq);
 	bitmap_zero(xfer->sent_bitmap, PAGE_SIZE);
 	bitmap_zero(xfer->received_bitmap, PAGE_SIZE);
-	xfer->retry_deadline = ktime_add_ns(ktime_get(), REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS);
+	xfer->retry_deadline = ktime_add_ns(ktime_get(), ((u64)retry_interval_ms * NSEC_PER_MSEC));
 	xfer->retry_count = 0;
 
 	smp_wmb();
-	spin_lock(&hacky_spinlock);
-	hash_add(xfer_table, &xfer->node, xfer_hash((uintptr_t)cached_target));
-	spin_unlock(&hacky_spinlock);
+	spin_lock(&xfer_table_lock);
+	hash_add_rcu(xfer_table, &xfer->node, xfer_hash(xfer->hack));
+	spin_unlock(&xfer_table_lock);
 
 	void *tx_buf;
 	remote_numa_mem_refetch_t *refetch;
 	void **v = (void **)&refetch;
 	trprt->alloc_tx_buffer(sizeof(*refetch), &tx_buf, v);
 	if (!tx_buf || !refetch) {
-		spin_lock(&hacky_spinlock);
-		hash_del(&xfer->node);
-		spin_unlock(&hacky_spinlock);
+		cached_target->xfer_cookie = 0;
+		spin_lock(&xfer_table_lock);
+		hash_del_rcu(&xfer->node);
+		spin_unlock(&xfer_table_lock);
 		xfer_put(xfer);
 		return -ENOMEM;
 	}
@@ -672,12 +813,13 @@ int remote_numa_transport_refetch_page_async(
 	refetch->hdr.main_cookie   = donor->node_id;
 	refetch->hdr.donor_cookie  = donor->donor_cookie;
 	refetch->donor_pg_cookie   = donor_pg_cookie;
-	refetch->main_pg_cookie    = cached_target->main_pg_cookie;
+	refetch->main_pg_cookie    = xfer->hack;
 
 	if (trprt->tx_msg(trprt->trprt_ctx, donor->priv_return_info, tx_buf)) {
-		spin_lock(&hacky_spinlock);
-		hash_del(&xfer->node);
-		spin_unlock(&hacky_spinlock);
+		cached_target->xfer_cookie = 0;
+		spin_lock(&xfer_table_lock);
+		hash_del_rcu(&xfer->node);
+		spin_unlock(&xfer_table_lock);
 		xfer_put(xfer);
 		return -EIO;
 	}
@@ -719,8 +861,7 @@ static int remote_numa_rx_mem_pg_sync_xfer_from(
 		void *payload = ((u8 *)xfer) + sizeof(*xfer);
 		memcpy(dst + xfer->seq_num, payload, xfer->payload_len);
 	} else {
-		pr_debug("remote_numa: mem_sync for unknown/idle cookie=%llu ret=%d\n",
-			 xfer->receiver_pg_cookie, lookup_ret);
+		atomic_inc(&rn_sync_skip);
 	}
 
 	void *ack_buf;
@@ -769,21 +910,21 @@ int remote_numa_rx_mem_pg_sat_ack(
 	 *   main side has already timed out or retired the xfer.
 	 */
 	if (!xfer) {
+		atomic_inc(&rn_ack_drop_nf);
 		return 0;
 	}
 	if (ack->hack != xfer->hack) {
-		pr_debug("remote_numa: sat_ack hack mismatch main_cookie=%llu xfer_hack=%d ack_hack=%d\n",
-			 ack->main_pg_cookie, xfer->hack, ack->hack);
+		atomic_inc(&rn_ack_drop_hack);
 		xfer_put(xfer);
 		return 0;
 	}
 
 	/* mark done and publish donor cookie */
-	spin_lock(&hacky_spinlock);
+	spin_lock(&xfer->xfer_lock);
 	bitmap_fill(xfer->received_bitmap, PAGE_SIZE);
 	xfer->cached_pg->known_page->donor_pg_cookie = ack->donor_pg_cookie;
 	smp_wmb();
-	spin_unlock(&hacky_spinlock);
+	spin_unlock(&xfer->xfer_lock);
 	wake_up(&xfer->waitq);
 	xfer_put(xfer);
 	return 0;
@@ -798,10 +939,14 @@ int remote_numa_rx_mem_pg_sync_ack(
 	if (!xfer)
 		return -ENOENT;
 
+	bool done;
+	spin_lock(&xfer->xfer_lock);
 	bitmap_set(xfer->received_bitmap, ack->bottom_seq_num,
-		ack->top_seq_num - ack->bottom_seq_num);
+		   (ack->top_seq_num - ack->bottom_seq_num));
+	done = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
+	spin_unlock(&xfer->xfer_lock);
 
-	if (xfer_compute_max_contig(xfer) >= PAGE_SIZE)
+	if (done)
 	{
 		wake_up(&xfer->waitq);
 	}
@@ -828,11 +973,12 @@ int remote_numa_tx_mem_pg_sync_xfer_async(
 	if (!xfer)
 		return -ENOMEM;
 	refcount_set(&xfer->refcnt, 1);
+	spin_lock_init(&xfer->xfer_lock);
 
-	spin_lock(&hacky_spinlock);
-	xfer->hack = ++hack;
+	/* The xfer is private (not yet in xfer_table); init fields unlocked. */
 	xfer->cached_pg = victim;
 	xfer->lookup_cookie = (uintptr_t)victim;
+	victim->xfer_cookie = (uintptr_t)victim;
 	xfer->hdr_main_cookie = victim->known_page->donor_id;
 	xfer->hdr_donor_cookie = victim->known_page->donor_cookie;
 	xfer->target = pg;
@@ -844,15 +990,17 @@ int remote_numa_tx_mem_pg_sync_xfer_async(
 	init_waitqueue_head(&xfer->waitq);
 	bitmap_zero(xfer->sent_bitmap, PAGE_SIZE);
 	bitmap_zero(xfer->received_bitmap, PAGE_SIZE);
-	xfer->retry_deadline = ktime_add_ns(ktime_get(), REMOTE_NUMA_DEFGAULT_RETRY_INTERVAL_NS);
+	xfer->retry_deadline = ktime_add_ns(ktime_get(), ((u64)retry_interval_ms * NSEC_PER_MSEC));
 	xfer->retry_count = 0;
 
-	smp_wmb();
-	hash_add(xfer_table, &xfer->node, xfer_hash((uintptr_t)victim));
-
 	u16 seg_len = main_if->get_max_payload_len() - sizeof(remote_numa_mem_pg_xfer_t);
+
 	smp_wmb();
-	spin_unlock(&hacky_spinlock);
+
+	xfer->hack = atomic_inc_return(&hack);
+	spin_lock(&xfer_table_lock);
+	hash_add_rcu(xfer_table, &xfer->node, xfer_hash((uintptr_t)victim));
+	spin_unlock(&xfer_table_lock);
 
 	remote_numa_send_all_segments(xfer, seg_len);
 
@@ -863,22 +1011,29 @@ int remote_numa_tx_mem_pg_sync_xfer_async(
 /* Check if transfer is complete. Returns 0 if done, -EAGAIN if in progress, <0 on error */
 int remote_numa_check_transfer_complete(struct remote_numa_cached_page *cached_pg)
 {
-	main_xfer_state_t *xfer = xfer_get((uintptr_t)cached_pg);
+	main_xfer_state_t *xfer = xfer_get(cached_pg->xfer_cookie);
 	if (!xfer) {
 		/* Missing xfer state while caller still tracks a page: treat as error */
 		return -ENOENT;
 	}
 
 	/* Check if transfer is complete */
-	if (xfer_compute_max_contig(xfer) >= PAGE_SIZE) {
+	bool done;
+	spin_lock(&xfer->xfer_lock);
+	done = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
+	spin_unlock(&xfer->xfer_lock);
+
+	if (done) {
 		/* Transfer complete - clean up */
 		bool removed = false;
-		spin_lock(&hacky_spinlock);
+		spin_lock(&xfer_table_lock);
 		if (!hlist_unhashed(&xfer->node)) {
-			hash_del(&xfer->node);
+			hash_del_rcu(&xfer->node);
 			removed = true;
 		}
-		spin_unlock(&hacky_spinlock);
+		spin_unlock(&xfer_table_lock);
+		if (removed && xfer->cached_pg->xfer_cookie == xfer->lookup_cookie)
+			xfer->cached_pg->xfer_cookie = 0;
 		/* Drop the table's reference (if we removed it). */
 		if (removed)
 			xfer_put(xfer);
@@ -1139,6 +1294,8 @@ int remote_numa_rx_mem_resp(
 	node->donor_cookie = resp->hdr.donor_cookie;
 	spin_unlock(&node->node_lock);
 
+	printk(KERN_INFO "remote_numa: mem_resp from node=%u free_pages=%u page_size_rank=%u (valid_mem_resp now set)\n",
+	       node->node_id, resp->free_pages, resp->page_size_rank);
 	return 0;
 }
 
@@ -1164,7 +1321,7 @@ static int remote_numa_rx_mem_alloc_from(
     }
 
     if (remote_numa_mem_alloc_page(mgr, &cookie, &page) != 0) {
-        printk(KERN_DEBUG "Bad page alloc manager in donor.\n");
+        atomic_inc(&rn_dmf_fail);
 		return -ENOMEM;
     }
 
@@ -1264,18 +1421,12 @@ int remote_numa_rx_mem_pg_free_ack(
 	remote_numa_mem_free_ack_t *ack)
 {
 	/*
-	 * Current main-side free path is fire-and-forget; we don't track an xfer
-	 * for mem_free, so there may be no matching state here. Treat the ACK as
-	 * advisory only and ignore it if we have nothing to wake.
+	 * The main-side free path is fire-and-forget; no xfer is tracked for
+	 * mem_free. The ack's main_pg_cookie identifies the entry as it was at
+	 * free time, which may since have been reused for a different page's
+	 * in-flight xfer, so it must never be used to complete an unrelated
+	 * transfer. Ignore the ack.
 	 */
-	main_xfer_state_t *xfer = xfer_get(ack->main_pg_cookie);
-	if (!xfer)
-		return 0;
-
-	bitmap_fill(xfer->received_bitmap, PAGE_SIZE);
-	wake_up(&xfer->waitq);
-	xfer_put(xfer);
-
 	return 0;
 }
 
@@ -1326,7 +1477,7 @@ int remote_numa_rx_mem_pg_refetch_sat(
 	main_xfer_state_t *xfer = xfer_get(sat->receiver_pg_cookie);
     if (!xfer)
     {
-	return -ENOENT;
+	return 0;
     }
     if (sat->payload_len + sat->seq_num > PAGE_SIZE)
 	{
@@ -1338,8 +1489,17 @@ int remote_numa_rx_mem_pg_refetch_sat(
     void *dst = page_address(xfer->target);
     memcpy(dst + sat->seq_num, ((u8 *)sat) + sizeof(*sat), sat->payload_len);
 
+    /* Track whether the main node received a zeroed page (corruption indicator). */
+    if (sat->seq_num == 0) {
+        atomic_inc(&rn_mrw_write);
+        if (((u8 *)dst)[0] == 0)
+            atomic_inc(&rn_mrw_first_zero);
+    }
+
     /* mark locally received so waiters can complete */
-    bitmap_set(xfer->received_bitmap, sat->seq_num, sat->payload_len);
+	spin_lock(&xfer->xfer_lock);
+	bitmap_set(xfer->received_bitmap, sat->seq_num, sat->payload_len);
+	spin_unlock(&xfer->xfer_lock);
 
     /* build ACK with bottom/top = [seq, seq+len), like sync */
     void *ack_buf;
@@ -1379,7 +1539,12 @@ int remote_numa_rx_mem_pg_refetch_sat(
     }
 
     /* done? wake any waiters */
-    if (xfer_compute_max_contig(xfer) >= PAGE_SIZE) {
+    bool done;
+    spin_lock(&xfer->xfer_lock);
+    done = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
+    spin_unlock(&xfer->xfer_lock);
+
+    if (done) {
 	        wake_up(&xfer->waitq);
 	        xfer_put(xfer);
 	} else {
@@ -1394,8 +1559,13 @@ remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
                                   remote_numa_mem_pg_xfer_ack_t *ack)
 {
 	main_xfer_state_t *xfer = xfer_get(ack->receiver_pg_cookie);
+    /*
+     * Best-effort ack handling: if the xfer is already gone (timed out or
+     * retired), drop the ACK silently. This avoids spurious ENOENT errors
+     * when the main side has already cleaned up the xfer.
+     */
     if (!xfer)
-		return -ENOENT;
+		return 0;
 
     /* Stale in-flight? Keep behavior consistent with sync_ack: log and continue. */
     if (ack->hack != xfer->hack) {
@@ -1406,12 +1576,16 @@ remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
     }
 
     /* Range-based ACK: handle out-of-order arrivals without over-marking. */
-    bitmap_set(xfer->received_bitmap,
-               ack->bottom_seq_num,
-               ack->top_seq_num - ack->bottom_seq_num);
+    bool done;
+    spin_lock(&xfer->xfer_lock);
+	bitmap_set(xfer->received_bitmap,
+		   ack->bottom_seq_num,
+		   (ack->top_seq_num - ack->bottom_seq_num));
+    done = xfer_compute_max_contig(xfer) >= PAGE_SIZE;
+    spin_unlock(&xfer->xfer_lock);
 
     /* If the page is fully covered, wake the waiter. */
-    if (xfer_compute_max_contig(xfer) >= PAGE_SIZE) {
+    if (done) {
 	        wake_up(&xfer->waitq);
 	        xfer_put(xfer);
 	} else {
@@ -1423,8 +1597,8 @@ remote_numa_rx_mem_pg_refetch_ack(struct remote_numa_donor_trprt_if *donor_if,
 
 void tmp_init(void)
 {
-	spin_lock_init(&hacky_spinlock);
-	hack = 0;
+	spin_lock_init(&xfer_table_lock);
+	atomic_set(&hack, 0);
 }
 EXPORT_SYMBOL_GPL(tmp_init);
 


### PR DESCRIPTION
Lots of automated testing from a local qwen 3.8 finding potential stability errors, mainly driven from manual prompting with increasingly difficult test cases. Change of locks to be more granular. Addition of debug counters to make debugging much easier and remove the need for parsing printk's, so we can instrument hot paths for the LLM.